### PR TITLE
Remove the lifetime parameter from GraphQLQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The CLI can now optionally format the generated code with rustfmt (enable the `rustfmt` feature).
 
+### Changed
+
+- (BREAKING) GraphQLQuery does not take a lifetime parameter anymore. This makes it easier to work with futures in async client, since futures expect everything they capture to have the 'static lifetime.
+
 ## 0.5.1 (2018-10-07)
 
 ### Added

--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -69,11 +69,11 @@ use itertools::Itertools;
 ///     Ok(())
 /// }
 /// ```
-pub trait GraphQLQuery<'de> {
+pub trait GraphQLQuery {
     /// The shape of the variables expected by the query. This should be a generated struct most of the time.
     type Variables: serde::Serialize;
     /// The top-level shape of the response data (the `data` field in the GraphQL response). In practice this should be generated, since it is hard to write by hand without error.
-    type ResponseData: serde::Deserialize<'de>;
+    type ResponseData: for<'de> serde::Deserialize<'de>;
 
     /// Produce a GraphQL query struct that can be JSON serialized and sent to a GraphQL API.
     fn build_query(variables: Self::Variables) -> QueryBody<Self::Variables>;

--- a/graphql_client_codegen/src/lib.rs
+++ b/graphql_client_codegen/src/lib.rs
@@ -170,7 +170,7 @@ pub fn generate_module_token_stream(
             #schema_output
         }
 
-        impl<'de> ::graphql_client::GraphQLQuery<'de> for #struct_name {
+        impl ::graphql_client::GraphQLQuery for #struct_name {
             type Variables = #module_name::Variables;
             type ResponseData = #module_name::ResponseData;
 


### PR DESCRIPTION
It makes it easier to work with async clients, since the 'de lifetime is scoped to the deserializer.

I would be interested in having feedback on this - I don't know if I might be breaking something. In my current effort on the browser client this makes things easier.