### PR TITLE
Make it possible to generate formatted code

### DIFF
--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -18,3 +18,9 @@ structopt = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+
+rustfmt-nightly = { version = "0.99" , optional = true }
+
+[features]
+default = []
+rustfmt = ["rustfmt-nightly"]

--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -10,6 +10,7 @@ pub fn generate_code(
     selected_operation: String,
     additional_derives: Option<String>,
     deprecation_strategy: Option<String>,
+    no_formatting: bool,
     output: PathBuf,
 ) -> Result<(), failure::Error> {
     let deprecation_strategy = deprecation_strategy.as_ref().map(|s| s.as_str());
@@ -25,8 +26,43 @@ pub fn generate_code(
         additional_derives,
         deprecation_strategy,
     };
+
     let gen = generate_module_token_stream(query_path, schema_path, Some(options))?;
-    let mut file = File::create(output)?;
-    write!(file, "{}", gen.to_string());
+
+    let mut file = File::create(output.clone())?;
+
+    let codes = gen.to_string();
+
+    if cfg!(feature = "rustfmt") && !no_formatting {
+        let codes = format(&codes);
+        write!(file, "{}", codes);
+    } else {
+        write!(file, "{}", codes);
+    }
+
     Ok(())
+}
+
+#[allow(unused_variables)]
+fn format(codes: &str) -> String {
+    #[cfg(feature = "rustfmt")]
+    {
+        use rustfmt::{Config, Input, Session};
+        use std::default::Default;
+
+        let mut config = Config::default();
+
+        config.set().emit_mode(rustfmt_nightly::EmitMode::Stdout);
+        config.set().verbose(rustfmt_nightly::Verbosity::Quiet);
+
+        let mut out = Vec::with_capacity(codes.len() * 2);
+
+        Session::new(config, Some(&mut out))
+            .format(Input::Text(codes.to_string()))
+            .unwrap_or_else(|err| panic!("rustfmt error: {}", err));
+
+        return String::from_utf8(out).unwrap();
+    }
+    #[cfg(not(feature = "rustfmt"))]
+    unreachable!()
 }

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -1,5 +1,6 @@
 extern crate failure;
 extern crate reqwest;
+
 #[macro_use]
 extern crate structopt;
 #[macro_use]
@@ -9,6 +10,9 @@ extern crate graphql_client_codegen;
 extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
+
+#[cfg(feature = "rustfmt")]
+extern crate rustfmt_nightly as rustfmt;
 
 mod generate;
 mod introspect_schema;
@@ -46,8 +50,13 @@ enum Cli {
         additional_derives: Option<String>,
         /// You can choose deprecation strategy from allow, deny, or warn.
         /// Default value is warn.
-        #[structopt(short = "d", long = "deprecation-strategy",)]
+        #[structopt(short = "d", long = "deprecation-strategy")]
         deprecation_strategy: Option<String>,
+        /// If you don't want to execute rustfmt to generated code, set this option.
+        /// Default value is false.
+        /// Formating feature is disabled as default installation.
+        #[structopt(long = "no-formatting")]
+        no_formatting: bool,
         #[structopt(parse(from_os_str))]
         output: PathBuf,
     },
@@ -67,6 +76,7 @@ fn main() -> Result<(), failure::Error> {
             selected_operation,
             additional_derives,
             deprecation_strategy,
+            no_formatting,
             output,
         } => generate::generate_code(
             query_path,
@@ -74,6 +84,7 @@ fn main() -> Result<(), failure::Error> {
             selected_operation,
             additional_derives,
             deprecation_strategy,
+            no_formatting,
             output,
         ),
     }


### PR DESCRIPTION
I make it possible to generate formatted code.

When users install cli with option like this,
`cargo install graphql_client_cli --features rustfmt`,
graphql-client generate command generate formatted code by rustfmt.

If users don't want to generate formatted code, they should execute command with `--no-formatting`