### PR TITLE
Create graphql_client README.md

### DIFF
--- a/graphql_client/README.md
+++ b/graphql_client/README.md
@@ -1,0 +1,11 @@
+# graphql_client
+
+[![Build Status](https://travis-ci.org/graphql-rust/graphql-client.svg?branch=master)](https://travis-ci.org/graphql-rust/graphql-client)
+[![docs](https://docs.rs/graphql_client/badge.svg)](https://docs.rs/graphql_client/latest/graphql_client/)
+[![crates.io](https://img.shields.io/crates/v/graphql_client.svg)](https://crates.io/crates/graphql_client)
+[![Join the chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/juniper-graphql/graphql-client)
+
+A typed GraphQL client library for Rust.
+
+## Refer to the root README
+https://raw.githubusercontent.com/graphql-rust/graphql-client/master/README.md


### PR DESCRIPTION
A readme within graphql_client that refers back to the root readme