### PR TITLE
Add extra-traits features to graphql-query-derive's syn dependency

### DIFF
--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -11,6 +11,6 @@ proc-macro = true
 
 [dependencies]
 failure = "0.1"
-syn = "0.15.20"
+syn = { version = "0.15.20", features = ["extra-traits"] }
 proc-macro2 = { version = "0.4", features = [] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.5.1" }

--- a/graphql_query_derive/src/attributes.rs
+++ b/graphql_query_derive/src/attributes.rs
@@ -2,7 +2,7 @@ use failure;
 use graphql_client_codegen::deprecation::DeprecationStrategy;
 use syn;
 
-const DEPRECATION_ERROR: &'static str = "deprecated must be one of 'allow', 'deny', or 'warn'";
+const DEPRECATION_ERROR: &str = "deprecated must be one of 'allow', 'deny', or 'warn'";
 
 /// The `graphql` attribute as a `syn::Path`.
 fn path_to_match() -> syn::Path {


### PR DESCRIPTION
When I built graphql_query_derive, I get compile error like this.

```
   Compiling graphql_query_derive v0.5.1 (/home/h-michael/ghq/github.com/h-michael/graphql-client/graphql_query_derive)
error[E0369]: binary operation `==` cannot be applied to type `syn::Path`
  --> graphql_query_derive/src/attributes.rs:18:22
   |
18 |         .find(|attr| attr.path == graphql_path)
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: an implementation of `std::cmp::PartialEq` might be missing for `syn::Path`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0369`.
error: failed to compile `graphql_client_cli v0.5.1-alpha.0 (/home/h-michael/ghq/github.com/h-michael/graphql-client/graphql_client_cli)`, intermediate artifacts can be found at `/home/h-michael/ghq/github.com/h-michael/graphql-client/target`

Caused by:
  Could not compile `graphql_query_derive`.
```

I think that we should change syn's features.
https://github.com/dtolnay/syn/blob/master/src/lib.rs#L233