### PR TITLE
Use default root operation type names when not specified

### DIFF
--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -69,20 +69,19 @@ pub(crate) fn response_for_query(
     }
 
     let response_data_fields = {
-        let opt_root_name = operation.root_name(&context.schema);
-        let root_name: &str = if let Some(root_name) = opt_root_name {
-            root_name
+        let root_name = operation.root_name(&context.schema);
+        let opt_definition = context
+            .schema
+            .objects
+            .get(&root_name);
+        let definition = if let Some(definition) = opt_definition {
+            definition
         } else {
             panic!(
                 "operation type '{:?}' not in schema",
                 operation.operation_type
             );
         };
-        let definition = context
-            .schema
-            .objects
-            .get(&root_name)
-            .expect("schema declaration is invalid");
         let prefix = &operation.name;
         let selection = &operation.selection;
 

--- a/graphql_client_codegen/src/operations.rs
+++ b/graphql_client_codegen/src/operations.rs
@@ -26,11 +26,11 @@ impl<'query> Operation<'query> {
     pub(crate) fn root_name<'schema>(
         &self,
         schema: &'schema ::schema::Schema,
-    ) -> Option<&'schema str> {
+    ) -> &'schema str {
         match self.operation_type {
-            OperationType::Query => schema.query_type,
-            OperationType::Mutation => schema.mutation_type,
-            OperationType::Subscription => schema.subscription_type,
+            OperationType::Query => schema.query_type.unwrap_or("Query"),
+            OperationType::Mutation => schema.mutation_type.unwrap_or("Mutation"),
+            OperationType::Subscription => schema.subscription_type.unwrap_or("Subscription"),
         }
     }
 


### PR DESCRIPTION
According to [the GraphQL spec](https://facebook.github.io/graphql/June2018/#sec-Root-Operation-Types):
> While any type can be the root operation type for a GraphQL operation, the type system definition language can omit the schema definition when the `query`, `mutation`, and `subscription` root types are named `Query`, `Mutation`, and `Subscription` respectively.
> 
> Likewise, when representing a GraphQL schema using the type system definition language, a schema definition should be omitted if it only uses the default root operation type names.

Actually, GitHub's introspection nowadays doesn't include schema definition at all.