### PR TITLE
Fix path to graphql_client in GitHub example

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tom Houlé <tom@tomhoule.com>"]
 
 [dependencies]
 failure = "*"
-graphql_client = { path = ".." }
+graphql_client = { path = "../../graphql_client" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
I confirmed my fix make the example work again on my local machine (macOS 10.12.6)