### PR TITLE
Include query file in generated modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Changes to query files will now always trigger code generation for the corresponding modules on the next build.
+
 ## 0.6.1 - 2019-01-19
 
 ### Added

--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -154,7 +154,7 @@ impl Display for PathFragment {
 ///         },
 ///         {
 ///             "message": "Seismic activity detected",
-///             "path": ["undeground", 20]
+///             "path": ["underground", 20]
 ///         },
 ///      ],
 /// }))?;
@@ -177,7 +177,7 @@ impl Display for PathFragment {
 ///             message: "Seismic activity detected".to_owned(),
 ///             locations: None,
 ///             path: Some(vec![
-///                 PathFragment::Key("undeground".into()),
+///                 PathFragment::Key("underground".into()),
 ///                 PathFragment::Index(20),
 ///             ]),
 ///             extensions: None,

--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -1,5 +1,7 @@
 use failure;
-use graphql_client_codegen::*;
+use graphql_client_codegen::{
+    deprecation, generate_module_token_stream, GraphQLClientCodegenOptions,
+};
 use std::fs::File;
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
@@ -12,12 +14,11 @@ pub fn generate_code(
     module_name: String,
     selected_operation: Option<String>,
     additional_derives: Option<String>,
-    deprecation_strategy: &Option<String>,
+    deprecation_strategy: Option<&str>,
     no_formatting: bool,
-    module_visibility: &Option<String>,
-    output: &PathBuf,
+    module_visibility: Option<&str>,
+    output: &Path,
 ) -> Result<(), failure::Error> {
-    let deprecation_strategy = deprecation_strategy.as_ref().map(|s| s.as_str());
     let deprecation_strategy = match deprecation_strategy {
         Some("allow") => Some(deprecation::DeprecationStrategy::Allow),
         Some("deny") => Some(deprecation::DeprecationStrategy::Deny),
@@ -25,7 +26,6 @@ pub fn generate_code(
         _ => None,
     };
 
-    let module_visibility = module_visibility.as_ref().map(|s| s.as_str());
     let module_visibility = match module_visibility {
         Some("pub") => syn::VisPublic {
             pub_token: <Token![pub]>::default(),
@@ -38,27 +38,35 @@ pub fn generate_code(
         .into(),
     };
 
-    let options = GraphQLClientDeriveOptions {
-        operation_name: selected_operation,
-        struct_name: None,
-        module_name: Some(module_name),
-        additional_derives,
-        deprecation_strategy,
-        module_visibility,
+    let mut options = GraphQLClientCodegenOptions::new_default();
+
+    options.set_module_name(module_name);
+    options.set_module_visibility(module_visibility);
+
+    if let Some(selected_operation) = selected_operation {
+        options.set_operation_name(selected_operation);
+    }
+
+    if let Some(additional_derives) = additional_derives {
+        options.set_additional_derives(additional_derives);
+    }
+
+    if let Some(deprecation_strategy) = deprecation_strategy {
+        options.set_deprecation_strategy(deprecation_strategy);
+    }
+
+    let gen = generate_module_token_stream(query_path, &schema_path, options)?;
+
+    let generated_code = gen.to_string();
+    let generated_code = if cfg!(feature = "rustfmt") && !no_formatting {
+        format(&generated_code)
+    } else {
+        generated_code
     };
 
-    let gen = generate_module_token_stream(query_path, &schema_path, Some(options))?;
+    let mut file = File::create(output)?;
 
-    let mut file = File::create(output.clone())?;
-
-    let codes = gen.to_string();
-
-    if cfg!(feature = "rustfmt") && !no_formatting {
-        let codes = format(&codes);
-        write!(file, "{}", codes)?;
-    } else {
-        write!(file, "{}", codes)?;
-    }
+    write!(file, "{}", generated_code)?;
 
     Ok(())
 }

--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -42,6 +42,7 @@ pub fn introspect_schema(
     let mut res = req_builder.json(&request_body).send()?;
 
     if res.status().is_success() {
+        // do nothing
     } else if res.status().is_server_error() {
         println!("server error!");
     } else {

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -100,9 +100,9 @@ fn main() -> Result<(), failure::Error> {
             module_name,
             selected_operation,
             additional_derives,
-            &deprecation_strategy,
+            deprecation_strategy.as_ref().map(String::as_str),
             no_formatting,
-            &module_visibility,
+            module_visibility.as_ref().map(String::as_str),
             &output,
         ),
     }

--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -38,7 +38,7 @@ pub(crate) fn response_for_query(
     schema: &schema::Schema,
     query: &query::Document,
     operation: &Operation,
-    additional_derives: Option<String>,
+    additional_derives: Option<&str>,
     deprecation_strategy: deprecation::DeprecationStrategy,
     multiple_operation: bool,
 ) -> Result<TokenStream, failure::Error> {

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -1,0 +1,110 @@
+use crate::deprecation::DeprecationStrategy;
+use heck::SnakeCase;
+use proc_macro2::{Ident, Span};
+use std::path::{Path, PathBuf};
+use syn::Visibility;
+
+/// Used to configure code generation.
+#[derive(Debug, Default)]
+pub struct GraphQLClientCodegenOptions {
+    /// Name of the operation we want to generate code for. If it does not match, we use all queries.
+    pub operation_name: Option<String>,
+    /// The name of implemention target struct.
+    pub struct_name: Option<String>,
+    /// The name of the module that will contains queries.
+    pub module_name: Option<String>,
+    /// Comma-separated list of additional traits we want to derive.
+    additional_derives: Option<String>,
+    /// The deprecation strategy to adopt.
+    deprecation_strategy: Option<DeprecationStrategy>,
+    /// Target module visibility.
+    module_visibility: Option<Visibility>,
+    /// A path to a file to include in the module to force Cargo to take into account changes in
+    /// the query files when recompiling.
+    query_file: Option<PathBuf>,
+    /// A path to a file to include in the module to force Cargo to take into account changes in
+    /// the schema files when recompiling.
+    schema_file: Option<PathBuf>,
+}
+
+impl GraphQLClientCodegenOptions {
+    /// Creates an empty options object with default params. It probably wants to be configured.
+    pub fn new_default() -> GraphQLClientCodegenOptions {
+        std::default::Default::default()
+    }
+
+    /// The module name, either one that was set explicitly, or the operation name, as snake case.
+    pub(crate) fn module_name_ident(&self) -> Option<Ident> {
+        self.module_name
+            .as_ref()
+            .or_else(|| self.operation_name.as_ref())
+            .map(|s| s.to_snake_case())
+            .map(|module_name| Ident::new(&module_name, Span::call_site()))
+    }
+
+    /// The visibility (public/private) to apply to the target module.
+    pub(crate) fn module_visibility(&self) -> &Visibility {
+        self.module_visibility
+            .as_ref()
+            .unwrap_or(&Visibility::Inherited)
+    }
+
+    /// The deprecation strategy to adopt.
+    pub(crate) fn deprecation_strategy(&self) -> DeprecationStrategy {
+        self.deprecation_strategy.clone().unwrap_or_default()
+    }
+
+    /// A path to a file to include in the module to force Cargo to take into account changes in
+    /// the query files when recompiling.
+    pub fn set_query_file(&mut self, path: PathBuf) {
+        self.query_file = Some(path);
+    }
+
+    /// Comma-separated list of additional traits we want to derive.
+    pub fn additional_derives(&self) -> Option<&str> {
+        self.additional_derives.as_ref().map(String::as_str)
+    }
+
+    /// Comma-separated list of additional traits we want to derive.
+    pub fn set_additional_derives(&mut self, additional_derives: String) {
+        self.additional_derives = Some(additional_derives);
+    }
+
+    /// The deprecation strategy to adopt.
+    pub fn set_deprecation_strategy(&mut self, deprecation_strategy: DeprecationStrategy) {
+        self.deprecation_strategy = Some(deprecation_strategy);
+    }
+
+    /// The name of the module that will contains queries.
+    pub fn set_module_name(&mut self, module_name: String) {
+        self.module_name = Some(module_name);
+    }
+
+    /// Target module visibility.
+    pub fn set_module_visibility(&mut self, visibility: Visibility) {
+        self.module_visibility = Some(visibility);
+    }
+
+    /// The name of implemention target struct.
+    pub fn set_struct_name(&mut self, struct_name: String) {
+        self.struct_name = Some(struct_name);
+    }
+
+    /// Name of the operation we want to generate code for. If none is selected, it means all
+    /// operations.
+    pub fn set_operation_name(&mut self, operation_name: String) {
+        self.operation_name = Some(operation_name);
+    }
+
+    /// A path to a file to include in the module to force Cargo to take into account changes in
+    /// the schema files when recompiling.
+    pub fn schema_file(&self) -> Option<&Path> {
+        self.schema_file.as_ref().map(PathBuf::as_path)
+    }
+
+    /// A path to a file to include in the module to force Cargo to take into account changes in
+    /// the query files when recompiling.
+    pub fn query_file(&self) -> Option<&Path> {
+        self.query_file.as_ref().map(PathBuf::as_path)
+    }
+}

--- a/graphql_client_codegen/src/deprecation.rs
+++ b/graphql_client_codegen/src/deprecation.rs
@@ -7,7 +7,7 @@ pub enum DeprecationStatus {
     Deprecated(Option<String>),
 }
 
-/// The available deprecation startegies.
+/// The available deprecation strategies.
 #[derive(Debug, PartialEq, Clone)]
 pub enum DeprecationStrategy {
     /// Allow use of deprecated items in queries, and say nothing.


### PR DESCRIPTION
This will force the regenaration the generated modules when query files
change.

See issue 215: https://github.com/graphql-rust/graphql-client/issues/215

Also extract GraphQLClientCodegenOptions to its own module, and use
accessors instead of a raw data struct.