### PR TITLE
Remove #[cfg(tests)] from build.rs

### DIFF
--- a/graphql_client/build.rs
+++ b/graphql_client/build.rs
@@ -1,9 +1,6 @@
 extern crate skeptic;
 
 fn main() {
-    #[cfg(tests)]
-    {
-        // Generates doc tests for the readme.
-        skeptic::generate_doc_tests(&["../README.md"]);
-    }
+    // Generates doc tests for the readme.
+    skeptic::generate_doc_tests(&["../README.md"]);
 }


### PR DESCRIPTION
See https://github.com/budziq/rust-skeptic/issues/60

I tried to use https://github.com/assert-rs/docmatic.
But we can't use that, because we use monorepo.