### PR TITLE
Adding the normalize_query_types feature to normalize all generated to CamelCase.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ script:
   - cargo test --all
   - cargo build --manifest-path=./examples/github/Cargo.toml
   - cargo build --manifest-path=./examples/web/Cargo.toml
+  - cargo build --manifest-path=./examples/hasura/Cargo.toml
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (xvfb-run cargo test --manifest-path=./graphql_client/Cargo.toml --features="web" --target wasm32-unknown-unknown) fi

--- a/examples/hasura/Cargo.toml
+++ b/examples/hasura/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "graphql_query_hasura_example"
+version = "0.1.0"
+authors = ["Mark Catley <mark@catley.net.nz>"]
+edition = "2018"
+
+[dependencies]
+failure = "*"
+graphql_client = { path = "../../graphql_client", features = [ "normalize_query_types" ] }
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+reqwest = "^0.9.0"
+prettytable-rs = "0.7.0"
+structopt = "0.2.10"
+dotenv = "0.13.0"
+envy = "0.3.2"
+log = "0.4.3"
+env_logger = "0.5.10"
+
+[workspace]
+members = ["."]

--- a/examples/hasura/README.md
+++ b/examples/hasura/README.md
@@ -1,0 +1,3 @@
+# graphql-client Hasura examples
+
+The schema was generated using (Hasura)[https://hasura.io/]. It is here to demonstrate the normalize_query_types feature and would require some work to create a Hasura instance that matches the schema. It is primarily present to ensure the feature compiles correctly.

--- a/examples/hasura/src/main.rs
+++ b/examples/hasura/src/main.rs
@@ -1,0 +1,67 @@
+// use failure::*;
+use graphql_client::*;
+use log::*;
+use prettytable::*;
+// use structopt::StructOpt;
+
+type Bpchar = String;
+type Timestamptz = String;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/schema.graphql",
+    query_path = "src/query_1.graphql",
+    response_derives = "Debug"
+)]
+struct UpsertIssue;
+
+fn main() -> Result<(), failure::Error> {
+    use upsert_issue::{IssuesUpdateColumn::*, *};
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    let q = UpsertIssue::build_query(Variables {
+        issues: vec![IssuesInsertInput {
+            id: Some("001000000000000".to_string()),
+            name: Some("Name".to_string()),
+            status: Some("Draft".to_string()),
+            salesforce_updated_at: Some("2019-06-11T08:14:28Z".to_string()),
+        }],
+        update_columns: vec![Name, Status, SalesforceUpdatedAt],
+    });
+
+    let client = reqwest::Client::new();
+
+    let mut res = client
+        .post("https://localhost:8080/v1/graphql")
+        .json(&q)
+        .send()?;
+
+    let response_body: Response<ResponseData> = res.json()?;
+    info!("{:?}", response_body);
+
+    if let Some(errors) = response_body.errors {
+        error!("there are errors:");
+
+        for error in &errors {
+            error!("{:?}", error);
+        }
+    }
+
+    let response_data = response_body.data.expect("missing response data");
+
+    let mut table = prettytable::Table::new();
+
+    table.add_row(row!(b => "id", "name"));
+
+    for issue in &response_data
+        .insert_issues
+        .expect("Inserted Issues")
+        .returning
+    {
+        table.add_row(row!(issue.id, issue.name));
+    }
+
+    table.printstd();
+    Ok(())
+}

--- a/examples/hasura/src/query_1.graphql
+++ b/examples/hasura/src/query_1.graphql
@@ -1,0 +1,14 @@
+mutation upsert_issue(
+  $issues: [issues_insert_input!]!
+  $update_columns: [issues_update_column!]!
+) {
+  insert_issues(
+    objects: $issues
+    on_conflict: { constraint: issues_pkey, update_columns: $update_columns }
+  ) {
+    returning {
+      id
+      name
+    }
+  }
+}

--- a/examples/hasura/src/schema.graphql
+++ b/examples/hasura/src/schema.graphql
@@ -1,0 +1,349 @@
+schema {
+  query: query_root
+  mutation: mutation_root
+  subscription: subscription_root
+}
+
+scalar bpchar
+
+# expression to compare columns of type bpchar. All fields are combined with logical 'AND'.
+input bpchar_comparison_exp {
+  _eq: bpchar
+  _gt: bpchar
+  _gte: bpchar
+  _in: [bpchar!]
+  _is_null: Boolean
+  _lt: bpchar
+  _lte: bpchar
+  _neq: bpchar
+  _nin: [bpchar!]
+}
+
+# conflict action
+enum conflict_action {
+  # ignore the insert on this row
+  ignore
+
+  # update the row with the given values
+  update
+}
+
+# columns and relationships of "issues"
+type issues {
+  id: bpchar!
+  name: String!
+  salesforce_updated_at: timestamptz!
+  status: String!
+}
+
+# aggregated selection of "issues"
+type issues_aggregate {
+  aggregate: issues_aggregate_fields
+  nodes: [issues!]!
+}
+
+# aggregate fields of "issues"
+type issues_aggregate_fields {
+  count(columns: [issues_select_column!], distinct: Boolean): Int
+  max: issues_max_fields
+  min: issues_min_fields
+}
+
+# order by aggregate values of table "issues"
+input issues_aggregate_order_by {
+  count: order_by
+  max: issues_max_order_by
+  min: issues_min_order_by
+}
+
+# input type for inserting array relation for remote table "issues"
+input issues_arr_rel_insert_input {
+  data: [issues_insert_input!]!
+  on_conflict: issues_on_conflict
+}
+
+# Boolean expression to filter rows from the table "issues". All fields are combined with a logical 'AND'.
+input issues_bool_exp {
+  _and: [issues_bool_exp]
+  _not: issues_bool_exp
+  _or: [issues_bool_exp]
+  id: bpchar_comparison_exp
+  name: text_comparison_exp
+  salesforce_updated_at: timestamptz_comparison_exp
+  status: text_comparison_exp
+}
+
+# unique or primary key constraints on table "issues"
+enum issues_constraint {
+  # unique or primary key constraint
+  issues_pkey
+}
+
+# input type for inserting data into table "issues"
+input issues_insert_input {
+  id: bpchar
+  name: String
+  salesforce_updated_at: timestamptz
+  status: String
+}
+
+# aggregate max on columns
+type issues_max_fields {
+  name: String
+  salesforce_updated_at: timestamptz
+  status: String
+}
+
+# order by max() on columns of table "issues"
+input issues_max_order_by {
+  name: order_by
+  salesforce_updated_at: order_by
+  status: order_by
+}
+
+# aggregate min on columns
+type issues_min_fields {
+  name: String
+  salesforce_updated_at: timestamptz
+  status: String
+}
+
+# order by min() on columns of table "issues"
+input issues_min_order_by {
+  name: order_by
+  salesforce_updated_at: order_by
+  status: order_by
+}
+
+# response of any mutation on the table "issues"
+type issues_mutation_response {
+  # number of affected rows by the mutation
+  affected_rows: Int!
+
+  # data of the affected rows by the mutation
+  returning: [issues!]!
+}
+
+# input type for inserting object relation for remote table "issues"
+input issues_obj_rel_insert_input {
+  data: issues_insert_input!
+  on_conflict: issues_on_conflict
+}
+
+# on conflict condition type for table "issues"
+input issues_on_conflict {
+  constraint: issues_constraint!
+  update_columns: [issues_update_column!]!
+}
+
+# ordering options when selecting data from "issues"
+input issues_order_by {
+  id: order_by
+  name: order_by
+  salesforce_updated_at: order_by
+  status: order_by
+}
+
+# select columns of table "issues"
+enum issues_select_column {
+  # column name
+  id
+
+  # column name
+  name
+
+  # column name
+  salesforce_updated_at
+
+  # column name
+  status
+}
+
+# input type for updating data in table "issues"
+input issues_set_input {
+  id: bpchar
+  name: String
+  salesforce_updated_at: timestamptz
+  status: String
+}
+
+# update columns of table "issues"
+enum issues_update_column {
+  # column name
+  id
+
+  # column name
+  name
+
+  # column name
+  salesforce_updated_at
+
+  # column name
+  status
+}
+
+# mutation root
+type mutation_root {
+  # delete data from the table: "issues"
+  delete_issues(
+    # filter the rows which have to be deleted
+    where: issues_bool_exp!
+  ): issues_mutation_response
+
+  # insert data into the table: "issues"
+  insert_issues(
+    # the rows to be inserted
+    objects: [issues_insert_input!]!
+
+    # on conflict condition
+    on_conflict: issues_on_conflict
+  ): issues_mutation_response
+
+  # update data of the table: "issues"
+  update_issues(
+    # sets the columns of the filtered rows to the given values
+    _set: issues_set_input
+
+    # filter the rows which have to be updated
+    where: issues_bool_exp!
+  ): issues_mutation_response
+}
+
+# column ordering options
+enum order_by {
+  # in the ascending order, nulls last
+  asc
+
+  # in the ascending order, nulls first
+  asc_nulls_first
+
+  # in the ascending order, nulls last
+  asc_nulls_last
+
+  # in the descending order, nulls first
+  desc
+
+  # in the descending order, nulls first
+  desc_nulls_first
+
+  # in the descending order, nulls last
+  desc_nulls_last
+}
+
+# query root
+type query_root {
+  # fetch data from the table: "issues"
+  issues(
+    # distinct select on columns
+    distinct_on: [issues_select_column!]
+
+    # limit the nuber of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [issues_order_by!]
+
+    # filter the rows returned
+    where: issues_bool_exp
+  ): [issues!]!
+
+  # fetch aggregated fields from the table: "issues"
+  issues_aggregate(
+    # distinct select on columns
+    distinct_on: [issues_select_column!]
+
+    # limit the nuber of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [issues_order_by!]
+
+    # filter the rows returned
+    where: issues_bool_exp
+  ): issues_aggregate!
+
+  # fetch data from the table: "issues" using primary key columns
+  issues_by_pk(id: bpchar!): issues
+}
+
+# subscription root
+type subscription_root {
+  # fetch data from the table: "issues"
+  issues(
+    # distinct select on columns
+    distinct_on: [issues_select_column!]
+
+    # limit the nuber of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [issues_order_by!]
+
+    # filter the rows returned
+    where: issues_bool_exp
+  ): [issues!]!
+
+  # fetch aggregated fields from the table: "issues"
+  issues_aggregate(
+    # distinct select on columns
+    distinct_on: [issues_select_column!]
+
+    # limit the nuber of rows returned
+    limit: Int
+
+    # skip the first n rows. Use only with order_by
+    offset: Int
+
+    # sort the rows by one or more columns
+    order_by: [issues_order_by!]
+
+    # filter the rows returned
+    where: issues_bool_exp
+  ): issues_aggregate!
+
+  # fetch data from the table: "issues" using primary key columns
+  issues_by_pk(id: bpchar!): issues
+}
+
+# expression to compare columns of type text. All fields are combined with logical 'AND'.
+input text_comparison_exp {
+  _eq: String
+  _gt: String
+  _gte: String
+  _ilike: String
+  _in: [String!]
+  _is_null: Boolean
+  _like: String
+  _lt: String
+  _lte: String
+  _neq: String
+  _nilike: String
+  _nin: [String!]
+  _nlike: String
+  _nsimilar: String
+  _similar: String
+}
+
+scalar timestamptz
+
+# expression to compare columns of type timestamptz. All fields are combined with logical 'AND'.
+input timestamptz_comparison_exp {
+  _eq: timestamptz
+  _gt: timestamptz
+  _gte: timestamptz
+  _in: [timestamptz!]
+  _is_null: Boolean
+  _lt: timestamptz
+  _lte: timestamptz
+  _neq: timestamptz
+  _nin: [timestamptz!]
+}

--- a/examples/web/src/lib.rs
+++ b/examples/web/src/lib.rs
@@ -60,7 +60,7 @@ fn add_load_more_button() {
         .expect_throw("could not create button");
     btn.set_inner_html("I WANT MORE PUPPIES");
     let on_click = Closure::wrap(
-        Box::new(move || future_to_promise(load_more())) as Box<FnMut() -> js_sys::Promise>
+        Box::new(move || future_to_promise(load_more())) as Box<dyn FnMut() -> js_sys::Promise>
     );
     btn.add_event_listener_with_callback(
         "click",

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -62,3 +62,4 @@ web = [
     "wasm-bindgen-futures",
     "web-sys",
 ]
+normalize_query_types = [ "graphql_query_derive/normalize_query_types" ]

--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -21,7 +21,7 @@ pub fn introspect_schema(
 ) -> Result<(), failure::Error> {
     use std::io::Write;
 
-    let out: Box<Write> = match output {
+    let out: Box<dyn Write> = match output {
         Some(path) => Box::new(::std::fs::File::create(path)?),
         None => Box::new(::std::io::stdout()),
     };

--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -17,3 +17,6 @@ serde = { version = "^1.0.78", features = ["derive"] }
 serde_json = "1.0"
 heck = "0.3"
 graphql-parser = "0.2.2"
+
+[features]
+normalize_query_types = []

--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -13,11 +13,22 @@ pub(crate) fn select_operation<'query>(
     query: &'query query::Document,
     struct_name: &str,
 ) -> Option<Operation<'query>> {
+    use heck::CamelCase;
+
     let operations = all_operations(query);
 
     operations
         .iter()
         .find(|op| op.name == struct_name)
+        .or_else(|| {
+            if cfg!(feature = "normalize_query_types") {
+                operations
+                    .iter()
+                    .find(|op| op.name.to_camel_case() == struct_name)
+            } else {
+                None
+            }
+        })
         .map(ToOwned::to_owned)
 }
 

--- a/graphql_client_codegen/src/enums.rs
+++ b/graphql_client_codegen/src/enums.rs
@@ -28,19 +28,37 @@ impl<'schema> GqlEnum<'schema> {
             .variants
             .iter()
             .map(|v| {
-                let name = Ident::new(&v.name, Span::call_site());
+                let name = v.name.to_string();
+                #[cfg(feature = "normalize_query_types")]
+                let name = {
+                    use heck::CamelCase;
+                    name.to_camel_case()
+                };
+                let name = Ident::new(&name, Span::call_site());
                 let description = &v.description;
                 let description = description.as_ref().map(|d| quote!(#[doc = #d]));
                 quote!(#description #name)
             })
             .collect();
         let variant_names = &variant_names;
-        let name_ident = Ident::new(&format!("{}{}", ENUMS_PREFIX, self.name), Span::call_site());
+        let name_ident = format!("{}{}", ENUMS_PREFIX, self.name);
+        #[cfg(feature = "normalize_query_types")]
+        let name_ident = {
+            use heck::CamelCase;
+            name_ident.to_camel_case()
+        };
+        let name_ident = Ident::new(&name_ident, Span::call_site());
         let constructors: Vec<_> = self
             .variants
             .iter()
             .map(|v| {
-                let v = Ident::new(&v.name, Span::call_site());
+                let v = v.name.to_string();
+                #[cfg(feature = "normalize_query_types")]
+                let v = {
+                    use heck::CamelCase;
+                    v.to_camel_case()
+                };
+                let v = Ident::new(&v, Span::call_site());
                 quote!(#name_ident::#v)
             })
             .collect();

--- a/graphql_client_codegen/src/field_type.rs
+++ b/graphql_client_codegen/src/field_type.rs
@@ -46,6 +46,16 @@ impl<'a> FieldType<'a> {
                     }
                     prefix.to_string()
                 };
+
+                #[cfg(feature = "normalize_query_types")]
+                let full_name = if full_name == "ID" || full_name.starts_with("__") {
+                    full_name
+                } else {
+                    use heck::CamelCase;
+
+                    full_name.to_camel_case()
+                };
+
                 let full_name = Ident::new(&full_name, Span::call_site());
 
                 quote!(#full_name)

--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -28,7 +28,15 @@ impl<'a> GeneratedModule<'a> {
         let module_name = Ident::new(&self.operation.name.to_snake_case(), Span::call_site());
         let module_visibility = &self.options.module_visibility();
         let operation_name_literal = &self.operation.name;
-        let operation_name_ident = Ident::new(&self.operation.name, Span::call_site());
+        let operation_name_ident = operation_name_literal.clone();
+        #[cfg(feature = "normalize_query_types")]
+        let operation_name_ident =
+            if Some(operation_name_ident.to_camel_case()) == self.options.operation_name {
+                operation_name_ident.to_camel_case()
+            } else {
+                operation_name_ident
+            };
+        let operation_name_ident = Ident::new(&operation_name_ident, Span::call_site());
 
         // Force cargo to refresh the generated code when the query file changes.
         let query_include = self

--- a/graphql_client_codegen/src/inputs.rs
+++ b/graphql_client_codegen/src/inputs.rs
@@ -69,7 +69,14 @@ impl<'schema> GqlInput<'schema> {
         &self,
         context: &QueryContext<'_, '_>,
     ) -> Result<TokenStream, failure::Error> {
-        let name = Ident::new(&self.name, Span::call_site());
+        let name = self.name;
+        #[cfg(feature = "normalize_query_types")]
+        let name = {
+            use heck::CamelCase;
+
+            name.to_camel_case()
+        };
+        let name = Ident::new(&name, Span::call_site());
         let mut fields: Vec<&GqlObjectField<'_>> = self.fields.values().collect();
         fields.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         let fields = fields.iter().map(|field| {

--- a/graphql_client_codegen/src/scalars.rs
+++ b/graphql_client_codegen/src/scalars.rs
@@ -12,7 +12,14 @@ impl<'schema> Scalar<'schema> {
     // TODO: do something smarter here
     pub fn to_rust(&self) -> proc_macro2::TokenStream {
         use proc_macro2::{Ident, Span};
-        let ident = Ident::new(&self.name, Span::call_site());
+        let name = self.name;
+        #[cfg(feature = "normalize_query_types")]
+        let name = {
+            use heck::CamelCase;
+
+            name.to_camel_case()
+        };
+        let ident = Ident::new(&name, Span::call_site());
         let description = match &self.description {
             Some(d) => quote!(#[doc = #d]),
             None => quote!(),

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -15,3 +15,6 @@ failure = "0.1"
 syn = { version = "0.15.20", features = ["extra-traits"] }
 proc-macro2 = { version = "0.4", features = [] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.8.0" }
+
+[features]
+normalize_query_types = [ "graphql_client_codegen/normalize_query_types" ]


### PR DESCRIPTION
This probably isn't the final solution to this issue but I made this change so that I could continue with what I was implementing. At a minimum, the readme would need to be updated to describe the feature.

I have added the normalize_query_types that normalises types (structs, type aliases, etc) generated by the code-gen to use CamelCase as it is my understanding that this is idiomatic rust. I have done this as a feature as it's potentially a breaking change.

I was having issues with scalars as described in #254 but then noticed that other types were non-idiomatic. 

Fixes #254 and fixes #255.