### PR TITLE
Fix structopt usage in the CLI tool

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2018"
 [dependencies]
 failure = "*"
 graphql_client = { path = "../../graphql_client" }
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-reqwest = "^0.9.0"
-prettytable-rs = "0.7.0"
-structopt = "0.2.10"
-dotenv = "0.13.0"
-envy = "0.3.2"
-log = "0.4.3"
-env_logger = "0.5.10"
+serde = "^1.0"
+serde_derive = "^1.0"
+serde_json = "^1.0"
+reqwest = "^0.9"
+prettytable-rs = "^0.7"
+structopt = "^0.2"
+dotenv = "^0.13"
+envy = "^0.3"
+log = "^0.4"
+env_logger = "^0.5"
 
 [workspace]
 members = ["."]

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -10,26 +10,26 @@ categories = ["network-programming", "web-programming", "wasm"]
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
+failure = "^0.1"
 graphql_query_derive = { path = "../graphql_query_derive", version = "0.8.0" }
-serde = { version = "^1.0.78", features = ["derive"] }
-serde_json = "1.0"
-doc-comment = "0.3.1"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+doc-comment = "^0.3"
 
 [dependencies.futures]
-version = "0.1"
+version = "^0.1"
 optional = true
 
 [dependencies.js-sys]
-version = "0.3.5"
+version = "^0.3"
 optional = true
 
 [dependencies.log]
-version = "0.4.6"
+version = "^0.4"
 optional = true
 
 [dependencies.web-sys]
-version = "0.3.2"
+version = "^0.3"
 optional = true
 features = [
     "Headers",
@@ -40,18 +40,18 @@ features = [
 ]
 
 [dependencies.wasm-bindgen]
-version = "0.2.43"
+version = "^0.2"
 optional = true
 
 [dependencies.wasm-bindgen-futures]
-version = "0.3.2"
+version = "^0.3"
 optional = true
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.reqwest]
-version = "0.9.16"
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+reqwest = "^0.9"
 
-[dev-dependencies.wasm-bindgen-test]
-version = "0.2.43"
+[dev-dependencies]
+wasm-bindgen-test = "^0.2"
 
 [features]
 web = [

--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -12,18 +12,18 @@ name = "graphql-client"
 path = "src/main.rs"
 
 [dependencies]
-failure = "0.1"
-reqwest = "^0.9.0"
+failure = "^0.1"
+reqwest = "^0.9"
 graphql_client = { version = "0.8.0", path = "../graphql_client" }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.8.0" }
-structopt = "0.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-syn = "0.15"
-log = "0.4.0"
-env_logger = "0.6.0"
+structopt = "0.2.18"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+syn = "^1.0"
+log = "^0.4"
+env_logger = "^0.6"
 
-rustfmt-nightly = { version = "0.99" , optional = true }
+rustfmt-nightly = { version = "1.4.5", optional = true }
 
 [features]
 default = []

--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -82,7 +82,6 @@ fn format(codes: &str) -> String {
     #[cfg(feature = "rustfmt")]
     {
         use rustfmt::{Config, Input, Session};
-        use std::default::Default;
 
         let mut config = Config::default();
 

--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -21,7 +21,7 @@ pub fn introspect_schema(
 ) -> Result<(), failure::Error> {
     use std::io::Write;
 
-    let out: Box<Write> = match output {
+    let out: Box<dyn Write> = match output {
         Some(path) => Box::new(::std::fs::File::create(path)?),
         None => Box::new(::std::io::stdout()),
     };

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -36,7 +36,7 @@ enum Cli {
         /// Path to the GraphQL query file.
         query_path: PathBuf,
         /// Name of target query. If you don't set this parameter, cli generate all queries in query file.
-        #[structopt(short = "o", long = "selected-operation")]
+        #[structopt(long = "selected-operation")]
         selected_operation: Option<String>,
         /// Additional derives that will be added to the generated structs and enums for the response and the variables.
         /// --additional-derives='Serialize,PartialEq'
@@ -59,7 +59,7 @@ enum Cli {
         ///
         /// If this option is omitted, the code will be generated next to the .graphql
         /// file, with the same name and the .rs extension.
-        #[structopt(short = "out", long = "output-directory")]
+        #[structopt(short = "o", long = "output-directory")]
         output_directory: Option<PathBuf>,
     },
 }

--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -8,12 +8,13 @@ repository = "https://github.com/graphql-rust/graphql-client"
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
-lazy_static = "1.0"
-quote = "0.6"
-syn = "0.15.20"
-proc-macro2 = { version = "0.4", features = [] }
-serde = { version = "^1.0.78", features = ["derive"] }
-serde_json = "1.0"
-heck = "0.3"
-graphql-parser = "0.2.2"
+failure = "^0.1"
+lazy_static = "^1.3"
+quote = "^1.0"
+syn = "^1.0"
+proc-macro2 = { version = "^1.0", features = [] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+heck = "^0.3"
+graphql-parser = "^0.2"
+derivative = "1.0.2"

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -1,4 +1,5 @@
 use crate::deprecation::DeprecationStrategy;
+use derivative::*;
 use proc_macro2::Ident;
 use std::path::{Path, PathBuf};
 use syn::Visibility;
@@ -13,7 +14,8 @@ pub enum CodegenMode {
 }
 
 /// Used to configure code generation.
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct GraphQLClientCodegenOptions {
     /// Which context is this code generation effort taking place.
     pub mode: CodegenMode,
@@ -28,6 +30,7 @@ pub struct GraphQLClientCodegenOptions {
     /// The deprecation strategy to adopt.
     deprecation_strategy: Option<DeprecationStrategy>,
     /// Target module visibility.
+    #[derivative(Debug = "ignore")]
     module_visibility: Option<Visibility>,
     /// A path to a file to include in the module to force Cargo to take into account changes in
     /// the query files when recompiling.

--- a/graphql_client_web/Cargo.toml
+++ b/graphql_client_web/Cargo.toml
@@ -15,5 +15,5 @@ path = "../graphql_client"
 features = ["web"]
 
 [dev-dependencies]
-serde = { version = "1", features = ["derive"] }
-wasm-bindgen-test = "0.2.25"
+serde = { version = "^1.0", features = ["derive"] }
+wasm-bindgen-test = "0.2.50"

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-failure = "0.1"
-syn = { version = "0.15.20", features = ["extra-traits"] }
-proc-macro2 = { version = "0.4", features = [] }
+failure = "^0.1"
+syn = { version = "^1.0", features = ["extra-traits"] }
+proc-macro2 = { version = "^1.0", features = [] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.8.0" }

--- a/graphql_query_derive/src/attributes.rs
+++ b/graphql_query_derive/src/attributes.rs
@@ -17,16 +17,15 @@ pub fn extract_attr(ast: &syn::DeriveInput, attr: &str) -> Result<String, failur
         .iter()
         .find(|attr| attr.path == graphql_path)
         .ok_or_else(|| format_err!("The graphql attribute is missing"))?;
-    if let syn::Meta::List(items) = &attribute
-        .interpret_meta()
-        .expect("Attribute is well formatted")
-    {
+    if let syn::Meta::List(items) = &attribute.parse_meta().expect("Attribute is well formatted") {
         for item in items.nested.iter() {
             if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = item {
-                let syn::MetaNameValue { ident, lit, .. } = name_value;
-                if ident == attr {
-                    if let syn::Lit::Str(lit) = lit {
-                        return Ok(lit.value());
+                let syn::MetaNameValue { path, lit, .. } = name_value;
+                if let Some(ident) = path.get_ident() {
+                    if ident == attr {
+                        if let syn::Lit::Str(lit) = lit {
+                            return Ok(lit.value());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Depends on #253

Fix structopt usage in the CLI tool. Potential breaking change!
    
structopt uses the first letter for a "short" option.
"selected_operation" (with "o") as well as "output_directory" (with "out")
claimed "-o" which resulted in:
    
      thread 'main' panicked at 'Argument short must be unique
    	-o is already in use
    
Fixed by removing the short option for "selected_operation" and keep "-o" for output directory.

This fixes the fix introduced in 0.7.1. I guess that `structopt` got more strict after the version update.