### PR TITLE
Don't serialize Option::None for Inputs

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2018"
 [dependencies]
 failure = "*"
 graphql_client = { path = "../../graphql_client" }
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-reqwest = "^0.9.0"
-prettytable-rs = "0.7.0"
-structopt = "0.2.10"
-dotenv = "0.13.0"
-envy = "0.3.2"
-log = "0.4.3"
-env_logger = "0.5.10"
+serde = "^1.0"
+serde_derive = "^1.0"
+serde_json = "^1.0"
+reqwest = "^0.9"
+prettytable-rs = "^0.7"
+structopt = "^0.2"
+dotenv = "^0.13"
+envy = "^0.3"
+log = "^0.4"
+env_logger = "^0.5"
 
 [workspace]
 members = ["."]

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -10,26 +10,26 @@ categories = ["network-programming", "web-programming", "wasm"]
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
+failure = "^0.1"
 graphql_query_derive = { path = "../graphql_query_derive", version = "0.8.0" }
-serde = { version = "^1.0.78", features = ["derive"] }
-serde_json = "1.0"
-doc-comment = "0.3.1"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+doc-comment = "^0.3"
 
 [dependencies.futures]
-version = "0.1"
+version = "^0.1"
 optional = true
 
 [dependencies.js-sys]
-version = "0.3.5"
+version = "^0.3"
 optional = true
 
 [dependencies.log]
-version = "0.4.6"
+version = "^0.4"
 optional = true
 
 [dependencies.web-sys]
-version = "0.3.2"
+version = "^0.3"
 optional = true
 features = [
     "Headers",
@@ -40,18 +40,18 @@ features = [
 ]
 
 [dependencies.wasm-bindgen]
-version = "0.2.43"
+version = "^0.2"
 optional = true
 
 [dependencies.wasm-bindgen-futures]
-version = "0.3.2"
+version = "^0.3"
 optional = true
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies.reqwest]
-version = "0.9.16"
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+reqwest = "^0.9"
 
-[dev-dependencies.wasm-bindgen-test]
-version = "0.2.43"
+[dev-dependencies]
+wasm-bindgen-test = "^0.2"
 
 [features]
 web = [

--- a/graphql_client/tests/input_object_variables.rs
+++ b/graphql_client/tests/input_object_variables.rs
@@ -58,14 +58,14 @@ fn recursive_input_objects_can_be_constructed() {
 
     RecursiveInput {
         head: "hello".to_string(),
-        tail: Box::new(None),
+        tail: None,
     };
 
     RecursiveInput {
         head: "hi".to_string(),
-        tail: Box::new(Some(RecursiveInput {
+        tail: Some(Box::new(RecursiveInput {
             head: "this is crazy".to_string(),
-            tail: Box::new(None),
+            tail: None,
         })),
     };
 }
@@ -84,14 +84,14 @@ fn indirectly_recursive_input_objects_can_be_constructed() {
 
     IndirectlyRecursiveInput {
         head: "hello".to_string(),
-        tail: Box::new(None),
+        tail: None,
     };
 
     IndirectlyRecursiveInput {
         head: "hi".to_string(),
-        tail: Box::new(Some(IndirectlyRecursiveInputTailPart {
+        tail: Some(Box::new(IndirectlyRecursiveInputTailPart {
             name: "this is crazy".to_string(),
-            recursed_field: Box::new(None),
+            recursed_field: None,
         })),
     };
 }

--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -12,18 +12,18 @@ name = "graphql-client"
 path = "src/main.rs"
 
 [dependencies]
-failure = "0.1"
-reqwest = "^0.9.0"
+failure = "^0.1"
+reqwest = "^0.9"
 graphql_client = { version = "0.8.0", path = "../graphql_client" }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.8.0" }
-structopt = "0.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-syn = "0.15"
-log = "0.4.0"
-env_logger = "0.6.0"
+structopt = "0.2.18"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+syn = "^1.0"
+log = "^0.4"
+env_logger = "^0.6"
 
-rustfmt-nightly = { version = "0.99" , optional = true }
+rustfmt-nightly = { version = "1.4.5", optional = true }
 
 [features]
 default = []

--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -82,7 +82,6 @@ fn format(codes: &str) -> String {
     #[cfg(feature = "rustfmt")]
     {
         use rustfmt::{Config, Input, Session};
-        use std::default::Default;
 
         let mut config = Config::default();
 

--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -21,7 +21,7 @@ pub fn introspect_schema(
 ) -> Result<(), failure::Error> {
     use std::io::Write;
 
-    let out: Box<Write> = match output {
+    let out: Box<dyn Write> = match output {
         Some(path) => Box::new(::std::fs::File::create(path)?),
         None => Box::new(::std::io::stdout()),
     };

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -36,7 +36,7 @@ enum Cli {
         /// Path to the GraphQL query file.
         query_path: PathBuf,
         /// Name of target query. If you don't set this parameter, cli generate all queries in query file.
-        #[structopt(short = "o", long = "selected-operation")]
+        #[structopt(long = "selected-operation")]
         selected_operation: Option<String>,
         /// Additional derives that will be added to the generated structs and enums for the response and the variables.
         /// --additional-derives='Serialize,PartialEq'
@@ -59,7 +59,7 @@ enum Cli {
         ///
         /// If this option is omitted, the code will be generated next to the .graphql
         /// file, with the same name and the .rs extension.
-        #[structopt(short = "out", long = "output-directory")]
+        #[structopt(short = "o", long = "output-directory")]
         output_directory: Option<PathBuf>,
     },
 }

--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -8,12 +8,13 @@ repository = "https://github.com/graphql-rust/graphql-client"
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
-lazy_static = "1.0"
-quote = "0.6"
-syn = "0.15.20"
-proc-macro2 = { version = "0.4", features = [] }
-serde = { version = "^1.0.78", features = ["derive"] }
-serde_json = "1.0"
-heck = "0.3"
-graphql-parser = "0.2.2"
+failure = "^0.1"
+lazy_static = "^1.3"
+quote = "^1.0"
+syn = "^1.0"
+proc-macro2 = { version = "^1.0", features = [] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
+heck = "^0.3"
+graphql-parser = "^0.2"
+derivative = "1.0.2"

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -1,4 +1,5 @@
 use crate::deprecation::DeprecationStrategy;
+use derivative::*;
 use proc_macro2::Ident;
 use std::path::{Path, PathBuf};
 use syn::Visibility;
@@ -13,7 +14,8 @@ pub enum CodegenMode {
 }
 
 /// Used to configure code generation.
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct GraphQLClientCodegenOptions {
     /// Which context is this code generation effort taking place.
     pub mode: CodegenMode,
@@ -28,6 +30,7 @@ pub struct GraphQLClientCodegenOptions {
     /// The deprecation strategy to adopt.
     deprecation_strategy: Option<DeprecationStrategy>,
     /// Target module visibility.
+    #[derivative(Debug = "ignore")]
     module_visibility: Option<Visibility>,
     /// A path to a file to include in the module to force Cargo to take into account changes in
     /// the query files when recompiling.

--- a/graphql_client_codegen/src/field_type.rs
+++ b/graphql_client_codegen/src/field_type.rs
@@ -46,8 +46,9 @@ impl<'a> FieldType<'a> {
                     }
                     prefix.to_string()
                 };
-                let full_name = Ident::new(&full_name, Span::call_site());
 
+                let rust_safe_field_name = crate::shared::keyword_replace(&full_name);
+                let full_name = Ident::new(&rust_safe_field_name, Span::call_site());
                 quote!(#full_name)
             }
             FieldType::Optional(inner) => {

--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -28,7 +28,8 @@ impl<'a> GeneratedModule<'a> {
         let module_name = Ident::new(&self.operation.name.to_snake_case(), Span::call_site());
         let module_visibility = &self.options.module_visibility();
         let operation_name_literal = &self.operation.name;
-        let operation_name_ident = Ident::new(&self.operation.name.to_camel_case(), Span::call_site());
+        let operation_name_ident =
+            Ident::new(&self.operation.name.to_camel_case(), Span::call_site());
 
         // Force cargo to refresh the generated code when the query file changes.
         let query_include = self

--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -52,6 +52,13 @@ impl<'a> GeneratedModule<'a> {
             CodegenMode::Derive => quote!(),
         };
 
+        let variables_type = match self.operation.variables.len() {
+            0 => quote!(()),
+            _ => quote!(
+            #module_name::Variables
+            ),
+        };
+
         Ok(quote!(
             #[allow(dead_code)]
             #struct_declaration
@@ -68,7 +75,7 @@ impl<'a> GeneratedModule<'a> {
             }
 
             impl graphql_client::GraphQLQuery for #operation_name_ident {
-                type Variables = #module_name::Variables;
+                type Variables = #variables_type;
                 type ResponseData = #module_name::ResponseData;
 
                 fn build_query(variables: Self::Variables) -> ::graphql_client::QueryBody<Self::Variables> {

--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -28,7 +28,7 @@ impl<'a> GeneratedModule<'a> {
         let module_name = Ident::new(&self.operation.name.to_snake_case(), Span::call_site());
         let module_visibility = &self.options.module_visibility();
         let operation_name_literal = &self.operation.name;
-        let operation_name_ident = Ident::new(&self.operation.name, Span::call_site());
+        let operation_name_ident = Ident::new(&self.operation.name.to_camel_case(), Span::call_site());
 
         // Force cargo to refresh the generated code when the query file changes.
         let query_include = self
@@ -52,6 +52,7 @@ impl<'a> GeneratedModule<'a> {
         };
 
         Ok(quote!(
+            #[allow(dead_code)]
             #struct_declaration
 
             #module_visibility mod #module_name {

--- a/graphql_client_codegen/src/inputs.rs
+++ b/graphql_client_codegen/src/inputs.rs
@@ -99,12 +99,16 @@ impl<'schema> GqlInput<'schema> {
 
         context.schema.require(&field.type_.inner_name_str());
         let rust_safe_field_name = crate::shared::keyword_replace(&field.name.to_snake_case());
-        let rename = crate::shared::field_rename_annotation(&field.name, &rust_safe_field_name);
+        let mut rename = crate::shared::field_rename_annotation(&field.name, &rust_safe_field_name);
         let name = Ident::new(&rust_safe_field_name, Span::call_site());
 
         match &field.type_ {
             crate::field_type::FieldType::Optional(_) => {
                 struct_field_assignments.push(quote!(#name: None));
+                rename = quote!(
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    #rename
+                )
             }
             _ => {
                 required_fields.push(quote!(#name: #ty));

--- a/graphql_client_codegen/src/operations.rs
+++ b/graphql_client_codegen/src/operations.rs
@@ -55,9 +55,16 @@ impl<'query> Operation<'query> {
             let ty = variable.ty.to_rust(context, "");
             let rust_safe_field_name =
                 crate::shared::keyword_replace(&variable.name.to_snake_case());
-            let rename =
+            let mut rename =
                 crate::shared::field_rename_annotation(&variable.name, &rust_safe_field_name);
             let name = Ident::new(&rust_safe_field_name, Span::call_site());
+
+            if let crate::field_type::FieldType::Optional(_) = &variable.ty {
+                rename = quote!(
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    #rename
+                )
+            }
 
             quote!(#rename pub #name: #ty)
         });

--- a/graphql_client_codegen/src/operations.rs
+++ b/graphql_client_codegen/src/operations.rs
@@ -55,11 +55,12 @@ impl<'query> Operation<'query> {
         }
 
         let fields = variables.iter().map(|variable| {
-            let name = &variable.name;
             let ty = variable.ty.to_rust(context, "");
-            let snake_case_name = name.to_snake_case();
-            let rename = crate::shared::field_rename_annotation(&name, &snake_case_name);
-            let name = Ident::new(&snake_case_name, Span::call_site());
+            let rust_safe_field_name =
+                crate::shared::keyword_replace(&variable.name.to_snake_case());
+            let rename =
+                crate::shared::field_rename_annotation(&variable.name, &rust_safe_field_name);
+            let name = Ident::new(&rust_safe_field_name, Span::call_site());
 
             quote!(#rename pub #name: #ty)
         });

--- a/graphql_client_codegen/src/operations.rs
+++ b/graphql_client_codegen/src/operations.rs
@@ -48,10 +48,7 @@ impl<'query> Operation<'query> {
         let variables_derives = context.variables_derives();
 
         if variables.is_empty() {
-            return quote! {
-                #variables_derives
-                pub struct Variables;
-            };
+            return quote! {};
         }
 
         let fields = variables.iter().map(|variable| {

--- a/graphql_client_codegen/src/query.rs
+++ b/graphql_client_codegen/src/query.rs
@@ -115,7 +115,6 @@ impl<'query, 'schema> QueryContext<'query, 'schema> {
     pub(crate) fn response_derives(&self) -> TokenStream {
         let derives: BTreeSet<&Ident> = self.response_derives.iter().collect();
         let derives = derives.iter();
-
         quote! {
             #[derive( #(#derives),* )]
         }
@@ -130,8 +129,9 @@ impl<'query, 'schema> QueryContext<'query, 'schema> {
             .response_derives
             .iter()
             .filter(|derive| {
-                !derive.to_string().contains("erialize")
-                    && !derive.to_string().contains("Deserialize")
+                // Do not apply the "Default" derive to enums.
+                let derive = derive.to_string();
+                derive != "Serialize" && derive != "Deserialize" && derive != "Default"
             })
             .collect();
         enum_derives.extend(always_derives.iter());

--- a/graphql_client_codegen/src/shared.rs
+++ b/graphql_client_codegen/src/shared.rs
@@ -7,6 +7,87 @@ use heck::{CamelCase, SnakeCase};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
+// List of keywords based on https://doc.rust-lang.org/grammar.html#keywords
+const RUST_KEYWORDS: &'static [&'static str] = &[
+    "abstract",
+    "alignof",
+    "as",
+    "async",
+    "await",
+    "become",
+    "box",
+    "break",
+    "const",
+    "continue",
+    "crate",
+    "do",
+    "else",
+    "enum",
+    "extern crate",
+    "extern",
+    "false",
+    "final",
+    "fn",
+    "for",
+    "for",
+    "if let",
+    "if",
+    "if",
+    "impl",
+    "impl",
+    "in",
+    "let",
+    "loop",
+    "macro",
+    "match",
+    "mod",
+    "move",
+    "mut",
+    "offsetof",
+    "override",
+    "priv",
+    "proc",
+    "pub",
+    "pure",
+    "ref",
+    "return",
+    "self",
+    "sizeof",
+    "static",
+    "struct",
+    "super",
+    "trait",
+    "true",
+    "type",
+    "typeof",
+    "unsafe",
+    "unsized",
+    "use",
+    "use",
+    "virtual",
+    "where",
+    "while",
+    "yield",
+];
+
+pub(crate) fn keyword_replace(needle: &str) -> String {
+    match RUST_KEYWORDS.binary_search(&needle) {
+        Ok(index) => [RUST_KEYWORDS[index], "_"].concat(),
+        Err(_) => needle.to_owned(),
+    }
+}
+
+mod tests {
+    #[test]
+    fn keyword_replace() {
+        use super::keyword_replace;
+        assert_eq!("fora", keyword_replace("fora"));
+        assert_eq!("in_", keyword_replace("in"));
+        assert_eq!("fn_", keyword_replace("fn"));
+        assert_eq!("struct_", keyword_replace("struct"));
+    }
+}
+
 pub(crate) fn render_object_field(
     field_name: &str,
     field_type: &TokenStream,
@@ -36,29 +117,9 @@ pub(crate) fn render_object_field(
 
     let description = description.map(|s| quote!(#[doc = #s]));
 
-    // List of keywords based on https://doc.rust-lang.org/grammar.html#keywords
-    let reserved = &[
-        "abstract", "alignof", "as", "become", "box", "break", "const", "continue", "crate", "do",
-        "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in", "let", "loop",
-        "macro", "match", "mod", "move", "mut", "offsetof", "override", "priv", "proc", "pub",
-        "pure", "ref", "return", "Self", "self", "sizeof", "static", "struct", "super", "trait",
-        "true", "type", "typeof", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
-    ];
-
-    if reserved.contains(&field_name) {
-        let name_ident = Ident::new(&format!("{}_", field_name), Span::call_site());
-        return quote! {
-            #description
-            #deprecation
-            #[serde(rename = #field_name)]
-            pub #name_ident: #field_type
-        };
-    }
-
-    let snake_case_name = field_name.to_snake_case();
-    let rename = crate::shared::field_rename_annotation(&field_name, &snake_case_name);
-    let name_ident = Ident::new(&snake_case_name, Span::call_site());
-
+    let rust_safe_field_name = keyword_replace(&field_name.to_snake_case());
+    let name_ident = Ident::new(&rust_safe_field_name, Span::call_site());
+    let rename = crate::shared::field_rename_annotation(&field_name, &rust_safe_field_name);
     quote!(#description #deprecation #rename pub #name_ident: #field_type)
 }
 

--- a/graphql_client_codegen/src/tests/keywords_query.graphql
+++ b/graphql_client_codegen/src/tests/keywords_query.graphql
@@ -1,0 +1,7 @@
+query searchQuery($criteria: extern!) {
+  search {
+    transactions(criteria:$searchID) {
+      for,status
+    }
+  }
+}

--- a/graphql_client_codegen/src/tests/keywords_schema.graphql
+++ b/graphql_client_codegen/src/tests/keywords_schema.graphql
@@ -1,0 +1,52 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""This directive allows results to be deferred during execution"""
+directive @defer on FIELD
+
+"""The top-level Query type."""
+type Query {
+  """Keyword type"""
+  search: Self
+}
+
+"""Keyword type"""
+type Self {
+  """
+  A keyword variable name with a keyword-named input type
+  """
+  transactions(struct: extern!): Result
+}
+
+"""Keyword type"""
+type Result {
+  """Keyword field."""
+  for: String
+  """dummy field with enum"""
+  status: AnEnum
+}
+
+
+"""Keyword input"""
+input extern {
+  """A field"""
+  id: crate
+}
+
+"""Input fields for searching for specific values."""
+input crate {
+  """Keyword field."""
+  enum: String
+
+  """Keyword field."""
+  in: [String!]
+}
+
+
+"""Enum with keywords"""
+enum AnEnum {
+  where
+  self
+}

--- a/graphql_client_codegen/src/tests/mod.rs
+++ b/graphql_client_codegen/src/tests/mod.rs
@@ -1,1 +1,43 @@
 mod github;
+
+#[test]
+fn schema_with_keywords_works() {
+    use crate::{
+        codegen, generated_module, schema::Schema, CodegenMode, GraphQLClientCodegenOptions,
+    };
+    use graphql_parser;
+
+    let query_string = include_str!("keywords_query.graphql");
+    let query = graphql_parser::parse_query(query_string).expect("Parse keywords query");
+    let schema = graphql_parser::parse_schema(include_str!("keywords_schema.graphql"))
+        .expect("Parse keywords schema");
+    let schema = Schema::from(&schema);
+
+    let options = GraphQLClientCodegenOptions::new(CodegenMode::Cli);
+    let operations = codegen::all_operations(&query);
+    for operation in &operations {
+        let generated_tokens = generated_module::GeneratedModule {
+            query_string: query_string,
+            schema: &schema,
+            query_document: &query,
+            operation,
+            options: &options,
+        }
+        .to_token_stream()
+        .expect("Generate keywords module");
+        let generated_code = generated_tokens.to_string();
+
+        // Parse generated code. All keywords should be correctly escaped.
+        let r: syn::parse::Result<proc_macro2::TokenStream> = syn::parse2(generated_tokens);
+        match r {
+            Ok(_) => {
+                // Rust keywords should be escaped / renamed now
+                assert!(generated_code.contains("pub in_"));
+                assert!(generated_code.contains("extern_"));
+            }
+            Err(e) => {
+                panic!("Error: {}\n Generated content: {}\n", e, &generated_code);
+            }
+        };
+    }
+}

--- a/graphql_client_web/Cargo.toml
+++ b/graphql_client_web/Cargo.toml
@@ -15,5 +15,5 @@ path = "../graphql_client"
 features = ["web"]
 
 [dev-dependencies]
-serde = { version = "1", features = ["derive"] }
-wasm-bindgen-test = "0.2.25"
+serde = { version = "^1.0", features = ["derive"] }
+wasm-bindgen-test = "0.2.50"

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-failure = "0.1"
-syn = { version = "0.15.20", features = ["extra-traits"] }
-proc-macro2 = { version = "0.4", features = [] }
+failure = "^0.1"
+syn = { version = "^1.0", features = ["extra-traits"] }
+proc-macro2 = { version = "^1.0", features = [] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.8.0" }

--- a/graphql_query_derive/src/attributes.rs
+++ b/graphql_query_derive/src/attributes.rs
@@ -17,16 +17,15 @@ pub fn extract_attr(ast: &syn::DeriveInput, attr: &str) -> Result<String, failur
         .iter()
         .find(|attr| attr.path == graphql_path)
         .ok_or_else(|| format_err!("The graphql attribute is missing"))?;
-    if let syn::Meta::List(items) = &attribute
-        .interpret_meta()
-        .expect("Attribute is well formatted")
-    {
+    if let syn::Meta::List(items) = &attribute.parse_meta().expect("Attribute is well formatted") {
         for item in items.nested.iter() {
             if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = item {
-                let syn::MetaNameValue { ident, lit, .. } = name_value;
-                if ident == attr {
-                    if let syn::Lit::Str(lit) = lit {
-                        return Ok(lit.value());
+                let syn::MetaNameValue { path, lit, .. } = name_value;
+                if let Some(ident) = path.get_ident() {
+                    if ident == attr {
+                        if let syn::Lit::Str(lit) = lit {
+                            return Ok(lit.value());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I have noticed that currently the library does not configure serde to skip Option::None and send json `null` values instead.

I'm not sure if it violates the graphql spec (https://graphql.github.io/graphql-spec/draft/#sec-Type-System.Non-Null.Nullable-vs-Optional), but not sending those fields is definitely allowed:

> Fields are always optional within the context of a query, a field may be omitted and the query is still valid. [...] Inputs (such as field arguments), are always optional by default. 

My graphql server however is absolutely not happy about `null` values for optional fields.
This PR adds the serde attribute to not serialize Option::None.

Requires all my other PRs for the sake of avoiding branch chaos on my side. If the last commit is fine, I'll be happy to extract and rebase it on master.