### PR TITLE
codegen: support distinct response and variable derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   are used, however, if set to `"rust"`, Rust naming rules will be used
   instead. This may become the default in future versions, since not normalizing
   names can lead to invalid code. (thanks @markcatley!)
+- `response_derives` now only applies to responses. Use `variables_derives` for
+  variable structure derives.
 
 ## Fixed
 

--- a/graphql_client/tests/default.rs
+++ b/graphql_client/tests/default.rs
@@ -1,0 +1,14 @@
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "tests/default/query.graphql",
+    schema_path = "tests/default/schema.graphql",
+    variables_derives = "Default"
+)]
+struct OptQuery;
+
+#[test]
+fn variables_can_derive_default() {
+    let _: <OptQuery as GraphQLQuery>::Variables = Default::default();
+}

--- a/graphql_client/tests/default/query.graphql
+++ b/graphql_client/tests/default/query.graphql
@@ -1,0 +1,6 @@
+query OptQuery($param: Param) {
+  optInput(query: $param) {
+    name
+    __typename
+  }
+}

--- a/graphql_client/tests/default/schema.graphql
+++ b/graphql_client/tests/default/schema.graphql
@@ -1,0 +1,21 @@
+schema {
+  query: Query
+}
+
+# The query type, represents all of the entry points into our object graph
+type Query {
+  optInput(query: Param): Named
+}
+
+# What can be searched for.
+enum Param {
+  AUTHOR
+}
+
+# A named entity
+type Named {
+  # The ID of the entity
+  id: ID!
+  # The name of the entity
+  name: String!
+}

--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -11,7 +11,8 @@ pub(crate) struct CliCodegenParams {
     pub query_path: PathBuf,
     pub schema_path: PathBuf,
     pub selected_operation: Option<String>,
-    pub additional_derives: Option<String>,
+    pub variables_derives: Option<String>,
+    pub response_derives: Option<String>,
     pub deprecation_strategy: Option<String>,
     pub no_formatting: bool,
     pub module_visibility: Option<String>,
@@ -20,7 +21,8 @@ pub(crate) struct CliCodegenParams {
 
 pub(crate) fn generate_code(params: CliCodegenParams) -> Result<(), failure::Error> {
     let CliCodegenParams {
-        additional_derives,
+        variables_derives,
+        response_derives,
         deprecation_strategy,
         no_formatting,
         output_directory,
@@ -45,8 +47,12 @@ pub(crate) fn generate_code(params: CliCodegenParams) -> Result<(), failure::Err
         options.set_operation_name(selected_operation);
     }
 
-    if let Some(additional_derives) = additional_derives {
-        options.set_additional_derives(additional_derives);
+    if let Some(variables_derives) = variables_derives {
+        options.set_variables_derives(variables_derives);
+    }
+
+    if let Some(response_derives) = response_derives {
+        options.set_response_derives(response_derives);
     }
 
     if let Some(deprecation_strategy) = deprecation_strategy {

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -39,10 +39,14 @@ enum Cli {
         /// Name of target query. If you don't set this parameter, cli generate all queries in query file.
         #[structopt(long = "selected-operation")]
         selected_operation: Option<String>,
-        /// Additional derives that will be added to the generated structs and enums for the response and the variables.
-        /// --additional-derives='Serialize,PartialEq'
-        #[structopt(short = "a", long = "additional-derives")]
-        additional_derives: Option<String>,
+        /// Additional derives that will be added to the generated structs and enums for the variables.
+        /// --variables-derives='Serialize,PartialEq'
+        #[structopt(short = "I", long = "variables-derives")]
+        variables_derives: Option<String>,
+        /// Additional derives that will be added to the generated structs and enums for the response.
+        /// --output-derives='Serialize,PartialEq'
+        #[structopt(short = "O", long = "response-derives")]
+        response_derives: Option<String>,
         /// You can choose deprecation strategy from allow, deny, or warn.
         /// Default value is warn.
         #[structopt(short = "d", long = "deprecation-strategy")]
@@ -77,7 +81,8 @@ fn main() -> Result<(), failure::Error> {
             headers,
         } => introspect_schema::introspect_schema(&schema_location, output, authorization, headers),
         Cli::Generate {
-            additional_derives,
+            variables_derives,
+            response_derives,
             deprecation_strategy,
             module_visibility,
             no_formatting,
@@ -86,7 +91,8 @@ fn main() -> Result<(), failure::Error> {
             schema_path,
             selected_operation,
         } => generate::generate_code(generate::CliCodegenParams {
-            additional_derives,
+            variables_derives,
+            response_derives,
             deprecation_strategy,
             module_visibility,
             no_formatting,

--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -47,8 +47,12 @@ pub(crate) fn response_for_query(
         options.normalization(),
     );
 
-    if let Some(derives) = options.additional_derives() {
-        context.ingest_additional_derives(&derives)?;
+    if let Some(derives) = options.variables_derives() {
+        context.ingest_variables_derives(&derives)?;
+    }
+
+    if let Some(derives) = options.response_derives() {
+        context.ingest_response_derives(&derives)?;
     }
 
     let mut definitions = Vec::new();

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -23,8 +23,10 @@ pub struct GraphQLClientCodegenOptions {
     pub struct_name: Option<String>,
     /// The struct for which we derive GraphQLQuery.
     struct_ident: Option<Ident>,
-    /// Comma-separated list of additional traits we want to derive.
-    additional_derives: Option<String>,
+    /// Comma-separated list of additional traits we want to derive for variables.
+    variables_derives: Option<String>,
+    /// Comma-separated list of additional traits we want to derive for responses.
+    response_derives: Option<String>,
     /// The deprecation strategy to adopt.
     deprecation_strategy: Option<DeprecationStrategy>,
     /// Target module visibility.
@@ -44,7 +46,8 @@ impl GraphQLClientCodegenOptions {
     pub fn new(mode: CodegenMode) -> GraphQLClientCodegenOptions {
         GraphQLClientCodegenOptions {
             mode,
-            additional_derives: Default::default(),
+            variables_derives: Default::default(),
+            response_derives: Default::default(),
             deprecation_strategy: Default::default(),
             module_visibility: Default::default(),
             operation_name: Default::default(),
@@ -74,14 +77,24 @@ impl GraphQLClientCodegenOptions {
         self.query_file = Some(path);
     }
 
-    /// Comma-separated list of additional traits we want to derive.
-    pub fn additional_derives(&self) -> Option<&str> {
-        self.additional_derives.as_ref().map(String::as_str)
+    /// Comma-separated list of additional traits we want to derive for variables.
+    pub fn variables_derives(&self) -> Option<&str> {
+        self.variables_derives.as_ref().map(String::as_str)
     }
 
-    /// Comma-separated list of additional traits we want to derive.
-    pub fn set_additional_derives(&mut self, additional_derives: String) {
-        self.additional_derives = Some(additional_derives);
+    /// Comma-separated list of additional traits we want to derive for variables.
+    pub fn set_variables_derives(&mut self, variables_derives: String) {
+        self.variables_derives = Some(variables_derives);
+    }
+
+    /// Comma-separated list of additional traits we want to derive for responses.
+    pub fn response_derives(&self) -> Option<&str> {
+        self.response_derives.as_ref().map(String::as_str)
+    }
+
+    /// Comma-separated list of additional traits we want to derive for responses.
+    pub fn set_response_derives(&mut self, response_derives: String) {
+        self.response_derives = Some(response_derives);
     }
 
     /// The deprecation strategy to adopt.

--- a/graphql_client_codegen/src/inputs.rs
+++ b/graphql_client_codegen/src/inputs.rs
@@ -235,7 +235,7 @@ mod tests {
         let mut schema = crate::schema::Schema::new();
         schema.inputs.insert(cat.name, cat);
         let mut context = QueryContext::new_empty(&schema);
-        context.ingest_additional_derives("Clone").unwrap();
+        context.ingest_variables_derives("Clone").unwrap();
 
         assert_eq!(
             format!(

--- a/graphql_client_codegen/src/query.rs
+++ b/graphql_client_codegen/src/query.rs
@@ -87,23 +87,36 @@ impl<'query, 'schema> QueryContext<'query, 'schema> {
         }
     }
 
-    pub(crate) fn ingest_additional_derives(
+    pub(crate) fn ingest_response_derives(
         &mut self,
         attribute_value: &str,
     ) -> Result<(), failure::Error> {
         if self.response_derives.len() > 1 {
             return Err(format_err!(
-                "ingest_additional_derives should only be called once"
+                "ingest_response_derives should only be called once"
             ));
         }
 
-        self.variables_derives.extend(
+        self.response_derives.extend(
             attribute_value
                 .split(',')
                 .map(str::trim)
                 .map(|s| Ident::new(s, Span::call_site())),
         );
-        self.response_derives.extend(
+        Ok(())
+    }
+
+    pub(crate) fn ingest_variables_derives(
+        &mut self,
+        attribute_value: &str,
+    ) -> Result<(), failure::Error> {
+        if self.variables_derives.len() > 1 {
+            return Err(format_err!(
+                "ingest_variables_derives should only be called once"
+            ));
+        }
+
+        self.variables_derives.extend(
             attribute_value
                 .split(',')
                 .map(str::trim)
@@ -160,7 +173,7 @@ mod tests {
         let mut context = QueryContext::new_empty(&schema);
 
         context
-            .ingest_additional_derives("PartialEq, PartialOrd, Serialize")
+            .ingest_response_derives("PartialEq, PartialOrd, Serialize")
             .unwrap();
 
         assert_eq!(
@@ -185,7 +198,7 @@ mod tests {
         let mut context = QueryContext::new_empty(&schema);
 
         context
-            .ingest_additional_derives("PartialEq, PartialOrd, Serialize")
+            .ingest_response_derives("PartialEq, PartialOrd, Serialize")
             .unwrap();
 
         assert_eq!(
@@ -200,8 +213,8 @@ mod tests {
         let mut context = QueryContext::new_empty(&schema);
 
         assert!(context
-            .ingest_additional_derives("PartialEq, PartialOrd")
+            .ingest_response_derives("PartialEq, PartialOrd")
             .is_ok());
-        assert!(context.ingest_additional_derives("Serialize").is_err());
+        assert!(context.ingest_response_derives("Serialize").is_err());
     }
 }

--- a/graphql_query_derive/src/lib.rs
+++ b/graphql_query_derive/src/lib.rs
@@ -61,13 +61,18 @@ fn build_graphql_client_derive_options(
     input: &syn::DeriveInput,
     query_path: PathBuf,
 ) -> Result<GraphQLClientCodegenOptions, failure::Error> {
+    let variables_derives = attributes::extract_attr(input, "variables_derives").ok();
     let response_derives = attributes::extract_attr(input, "response_derives").ok();
 
     let mut options = GraphQLClientCodegenOptions::new(CodegenMode::Derive);
     options.set_query_file(query_path);
 
+    if let Some(variables_derives) = variables_derives {
+        options.set_variables_derives(variables_derives);
+    };
+
     if let Some(response_derives) = response_derives {
-        options.set_additional_derives(response_derives);
+        options.set_response_derives(response_derives);
     };
 
     // The user can determine what to do about deprecations.


### PR DESCRIPTION
Instead of having just `additional_derives`, split them apart from each
other. The CLI interface also now follows this pattern.

Note: No backwards compatibility is provided in this commit.

---
See #248 #249 and #260.

This should allow one to set `response_derives` and `variables_derives` separately. For #260, adding `Default` should make it easier to handle all-optional input structures.

Cc: @tomhoule @davidgraeff @mikailbag