### PR TITLE
Update cli's README.md

### DIFF
--- a/graphql_client_cli/README.md
+++ b/graphql_client_cli/README.md
@@ -33,7 +33,7 @@ ARGS:
 
 ```
 USAGE:
-    graphql-client generate [FLAGS] [OPTIONS] <query_path> <schema_path>
+    graphql-client generate [FLAGS] [OPTIONS] <query_path> --schema-path <schema_path>
 
 FLAGS:
     -h, --help             Prints help information
@@ -48,16 +48,17 @@ OPTIONS:
     -d, --deprecation-strategy <deprecation_strategy>
             You can choose deprecation strategy from allow, deny, or warn. Default value is warn.
 
-    -m, --module_visibility <module_visibility>
+    -m, --module-visibility <module_visibility>
             You can choose module and target struct visibility from pub and private. Default value is pub.
 
+    -o, --output-directory <output_directory>            The directory in which the code will be generated
+    -s, --schema-path <schema_path>                      Path to GraphQL schema file (.json or .graphql).
     -o, --selected-operation <selected_operation>
             Name of target query. If you don't set this parameter, cli generate all queries in query file.
 
 
 ARGS:
-    <query_path>     Path to graphql query file.
-    <schema_path>    Path to graphql schema file.
+    <query_path>    Path to the GraphQL query file.
 ```
 
 If you want to use formatting feature, you should install like this.


### PR DESCRIPTION
Hi.
I'm new to this crate. 
I found there is old information on `graphql_client_cli/README.md` when I proceeded `Getting started` section.
I have replaced it with the latest output of `$ graphql-client generate -h`.