### PR TITLE
Allow disabling ssl verification on schema introspection

### DIFF
--- a/graphql_client_cli/README.md
+++ b/graphql_client_cli/README.md
@@ -19,7 +19,7 @@ USAGE:
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
-        --no_ssl     Set this option to disable ssl certificate verification. Default value is false.
+        --no-ssl     Set this option to disable ssl certificate verification. Default value is false.
                      ssl verification is turned on by default.
 
 OPTIONS:

--- a/graphql_client_cli/README.md
+++ b/graphql_client_cli/README.md
@@ -14,11 +14,13 @@ cargo install graphql_client_cli --force
 Get the schema from a live GraphQL API. The schema is printed to stdout.
 
 USAGE:
-    graphql-client introspect-schema [OPTIONS] <schema_location>
+    graphql-client introspect-schema [FLAGS] [OPTIONS] <schema_location>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
+        --no_ssl     Set this option to disable ssl certificate verification. Default value is false.
+                     ssl verification is turned on by default.
 
 OPTIONS:
         --authorization <authorization>    Set the contents of the Authorizaiton header.

--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -34,7 +34,9 @@ pub fn introspect_schema(
         operation_name: introspection_query::OPERATION_NAME,
     };
 
-    let client = reqwest::Client::builder().danger_accept_invalid_certs(no_ssl).build()?;
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(no_ssl)
+        .build()?;
 
     let mut req_builder = client.post(location).headers(construct_headers());
 

--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -19,6 +19,7 @@ pub fn introspect_schema(
     output: Option<PathBuf>,
     authorization: Option<String>,
     headers: Vec<Header>,
+    no_ssl: bool,
 ) -> anyhow::Result<()> {
     use std::io::Write;
 
@@ -33,7 +34,7 @@ pub fn introspect_schema(
         operation_name: introspection_query::OPERATION_NAME,
     };
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder().danger_accept_invalid_certs(no_ssl).build()?;
 
     let mut req_builder = client.post(location).headers(construct_headers());
 

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -84,7 +84,13 @@ fn main() -> anyhow::Result<()> {
             authorization,
             headers,
             no_ssl,
-        } => introspect_schema::introspect_schema(&schema_location, output, authorization, headers, no_ssl),
+        } => introspect_schema::introspect_schema(
+            &schema_location,
+            output,
+            authorization,
+            headers,
+            no_ssl,
+        ),
         Cli::Generate {
             variables_derives,
             response_derives,

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -28,6 +28,10 @@ enum Cli {
         /// --header 'X-Name: Value'
         #[structopt(long = "header")]
         headers: Vec<introspect_schema::Header>,
+        /// Disable ssl verification.
+        /// Default value is false.
+        #[structopt(long = "no-ssl")]
+        no_ssl: bool,
     },
     #[structopt(name = "generate")]
     Generate {
@@ -79,7 +83,8 @@ fn main() -> anyhow::Result<()> {
             output,
             authorization,
             headers,
-        } => introspect_schema::introspect_schema(&schema_location, output, authorization, headers),
+            no_ssl,
+        } => introspect_schema::introspect_schema(&schema_location, output, authorization, headers, no_ssl),
         Cli::Generate {
             variables_derives,
             response_derives,


### PR DESCRIPTION
### What this PR does

Introduces a flag for disabling SSL verification when using the `introspect-schema` command:

`no_ssl`: set this to disable SSL verification. The default value is false, so if the flag is not passed, SSL verification will be enabled.

### Why
My team recently decided to use `graphql_client_cli` for introspecting our GraphQL services but quickly realized that there was no way to do this on a host where https is enabled, hence this flag.

### Sample Usage:
```bash
$ graphql-client introspect-schema https:/localhost:8080/graphql --no-ssl --header 'Authorization: Basic a5WcefsppefwfeX2pB25Z3JhtleQ='
```