### PR TITLE
Fix: correct link to Apollo CLI

### DIFF
--- a/graphql_client_cli/README.md
+++ b/graphql_client_cli/README.md
@@ -1,6 +1,6 @@
 # GraphQL client CLI
 
-This is still a WIP, the main use for it now is to download the `schema.json` from a GraphQL endpoint, which you can also do with [apollo-codegen](https://github.com/apollographql/apollo-cli).
+This is still a WIP, the main use for it now is to download the `schema.json` from a GraphQL endpoint, which you can also do with [the Apollo CLI](https://github.com/apollographql/apollo-tooling#apollo-clientdownload-schema-output).
 
 ## Install
 


### PR DESCRIPTION
the docs currently link to Apollo's WIP CLI rather than the released CLI that actually has the functionality to download a `schema.json` from a GraphQL endpoint. - this PR fixes it and links to the docs for `apollo schema:download` :smile: 