### PR TITLE
Add use super::* to main code generation function

### DIFF
--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -44,6 +44,7 @@ pub(crate) fn response_for_query(
 
     let q = quote! {
         use serde::{Serialize, Deserialize};
+        use super::*;
 
         #[allow(dead_code)]
         type Boolean = bool;


### PR DESCRIPTION
This allows for arbitrary `response_derives` derive macros to be used.