### PR TITLE
doctest: Fix regression after upgrade of reqwest to 0.10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A typed GraphQL client library for Rust.
   ```rust
   use graphql_client::{GraphQLQuery, Response};
   use std::error::Error;
+  use reqwest;
 
   #[derive(GraphQLQuery)]
   #[graphql(
@@ -68,14 +69,14 @@ A typed GraphQL client library for Rust.
   )]
   pub struct UnionQuery;
 
-  fn perform_my_query(variables: union_query::Variables) -> Result<(), Box<dyn Error>> {
+  async fn perform_my_query(variables: union_query::Variables) -> Result<(), Box<dyn Error>> {
 
       // this is the important line
       let request_body = UnionQuery::build_query(variables);
 
       let client = reqwest::Client::new();
-      let mut res = client.post("/graphql").json(&request_body).send()?;
-      let response_body: Response<union_query::ResponseData> = res.json()?;
+      let mut res = client.post("/graphql").json(&request_body).send().await?;
+      let response_body: Response<union_query::ResponseData> = res.json().await?;
       println!("{:#?}", response_body);
       Ok(())
   }

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -41,6 +41,7 @@ optional = true
 [dev-dependencies]
 # Note: If we bumpup wasm-bindge-test version, we should change CI setting.
 wasm-bindgen-test = "^0.3"
+reqwest = { version = "^0.10", features = ["json", "blocking"] }
 
 [features]
 default = ["graphql_query_derive"]

--- a/graphql_client/src/web.rs
+++ b/graphql_client/src/web.rs
@@ -79,7 +79,7 @@ impl Client {
         _query: Q,
         variables: Q::Variables,
     ) -> Result<crate::Response<Q::ResponseData>, ClientError> {
-        let window = web_sys::window().ok_or_else(|| ClientError::NoWindow)?;
+        let window = web_sys::window().ok_or(ClientError::NoWindow)?;
         let body =
             serde_json::to_string(&Q::build_query(variables)).map_err(|_| ClientError::Body)?;
 


### PR DESCRIPTION
This was introduced in #350. Besides this, my thanks for upgrading
reqwest. The old version cost me some time yesterday.

I do not know why CI did not catch this. Maybe something for the maintainers to
take a look at. Or I made a mistake in my setup.

Below is the error I got:

```shell
---- /Users/user/.cargo/registry/src/github.com-1ecc6299db9ec823/doc-comment-0.3.3/src/lib.rs - (line 228) stdout ----
error[E0433]: failed to resolve: use of undeclared type or module `reqwest`
  --> /Users/user/.cargo/registry/src/github.com-1ecc6299db9ec823/doc-comment-0.3.3/src/lib.rs:245:27
   |
20 |     let client = reqwest::Client::new();
   |                           ^^^^^^ not found in `reqwest`
   |
help: consider importing this struct
   |
3  | use graphql_client::web::Client;
   |

error: aborting due to previous error
```
