### PR TITLE
Add an option to provide module for the custom scalar definitions

### DIFF
--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -17,6 +17,7 @@ pub(crate) struct CliCodegenParams {
     pub no_formatting: bool,
     pub module_visibility: Option<String>,
     pub output_directory: Option<PathBuf>,
+    pub custom_scalars_module: Option<String>,
 }
 
 pub(crate) fn generate_code(params: CliCodegenParams) -> Result<()> {
@@ -30,6 +31,7 @@ pub(crate) fn generate_code(params: CliCodegenParams) -> Result<()> {
         query_path,
         schema_path,
         selected_operation,
+        custom_scalars_module,
     } = params;
 
     let deprecation_strategy = deprecation_strategy.as_ref().and_then(|s| s.parse().ok());
@@ -57,6 +59,17 @@ pub(crate) fn generate_code(params: CliCodegenParams) -> Result<()> {
 
     if let Some(deprecation_strategy) = deprecation_strategy {
         options.set_deprecation_strategy(deprecation_strategy);
+    }
+
+    if let Some(custom_scalars_module) = custom_scalars_module {
+        let custom_scalars_module = syn::parse_str(&custom_scalars_module).with_context(|| {
+            format!(
+                "Invalid custom scalars module path: {}",
+                custom_scalars_module
+            )
+        })?;
+
+        options.set_custom_scalars_module(custom_scalars_module);
     }
 
     let gen = generate_module_token_stream(query_path.clone(), &schema_path, options).unwrap();

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -70,6 +70,10 @@ enum Cli {
         /// file, with the same name and the .rs extension.
         #[structopt(short = "o", long = "output-directory")]
         output_directory: Option<PathBuf>,
+        /// The module where the custom scalar definitions are located.
+        /// --custom-scalars-module='crate::gql::custom_scalars'
+        #[structopt(short = "p", long = "custom-scalars-module")]
+        custom_scalars_module: Option<String>,
     },
 }
 
@@ -101,6 +105,7 @@ fn main() -> anyhow::Result<()> {
             query_path,
             schema_path,
             selected_operation,
+            custom_scalars_module,
         } => generate::generate_code(generate::CliCodegenParams {
             variables_derives,
             response_derives,
@@ -111,6 +116,7 @@ fn main() -> anyhow::Result<()> {
             query_path,
             schema_path,
             selected_operation,
+            custom_scalars_module,
         }),
     }
 }

--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -156,7 +156,11 @@ fn generate_scalar_definitions<'a, 'schema: 'a>(
                 proc_macro2::Span::call_site(),
             );
 
-            quote!(type #ident = super::#ident;)
+            if let Some(custom_scalars_module) = options.custom_scalars_module() {
+                quote!(type #ident = #custom_scalars_module::#ident;)
+            } else {
+                quote!(type #ident = super::#ident;)
+            }
         })
 }
 

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -2,7 +2,7 @@ use crate::deprecation::DeprecationStrategy;
 use crate::normalization::Normalization;
 use proc_macro2::Ident;
 use std::path::{Path, PathBuf};
-use syn::Visibility;
+use syn::{self, Visibility};
 
 /// Which context is this code generation effort taking place.
 #[derive(Debug)]
@@ -39,6 +39,8 @@ pub struct GraphQLClientCodegenOptions {
     schema_file: Option<PathBuf>,
     /// Normalization pattern for query types and names.
     normalization: Normalization,
+    /// Custom scalar definitions module path
+    custom_scalars_module: Option<syn::Path>,
 }
 
 impl GraphQLClientCodegenOptions {
@@ -56,6 +58,7 @@ impl GraphQLClientCodegenOptions {
             query_file: Default::default(),
             schema_file: Default::default(),
             normalization: Normalization::None,
+            custom_scalars_module: Default::default(),
         }
     }
 
@@ -173,5 +176,15 @@ impl GraphQLClientCodegenOptions {
     /// The normalization mode for the generated code.
     pub fn normalization(&self) -> &Normalization {
         &self.normalization
+    }
+
+    /// Get the custom scalar definitions module
+    pub fn custom_scalars_module(&self) -> Option<&syn::Path> {
+        self.custom_scalars_module.as_ref()
+    }
+
+    /// Set the custom scalar definitions module
+    pub fn set_custom_scalars_module(&mut self, module: syn::Path) {
+        self.custom_scalars_module = Some(module)
     }
 }

--- a/graphql_query_derive/src/lib.rs
+++ b/graphql_query_derive/src/lib.rs
@@ -70,6 +70,7 @@ fn build_graphql_client_derive_options(
 ) -> Result<GraphQLClientCodegenOptions, BoxError> {
     let variables_derives = attributes::extract_attr(input, "variables_derives").ok();
     let response_derives = attributes::extract_attr(input, "response_derives").ok();
+    let custom_scalars_module = attributes::extract_attr(input, "custom_scalars_module").ok();
 
     let mut options = GraphQLClientCodegenOptions::new(CodegenMode::Derive);
     options.set_query_file(query_path);
@@ -91,6 +92,18 @@ fn build_graphql_client_derive_options(
     if let Ok(normalization) = attributes::extract_normalization(input) {
         options.set_normalization(normalization);
     };
+
+    // The user can give a path to a module that provides definitions for the custom scalars.
+    if let Some(custom_scalars_module) = custom_scalars_module {
+        let custom_scalars_module = syn::parse_str(&custom_scalars_module).map_err(|err| {
+            GeneralError(format!(
+                "Invalid custom scalars module path: {}. {}",
+                custom_scalars_module, err
+            ))
+        })?;
+
+        options.set_custom_scalars_module(custom_scalars_module);
+    }
 
     options.set_struct_ident(input.ident.clone());
     options.set_module_visibility(input.vis.clone());


### PR DESCRIPTION
### Description
Currently, the definitions for the custom scalars have to specified in the parent (`super` ) module.
For example if you have a custom `DateTime` scalar it generates for you `type DateTime = super::DateTime;`

This PR adds the option `custom_scalars_module` which can be used to specify the path to the module that contains the definitions for the custom scalars that are necessary for the generated query.

For the above example, setting this option to `crate::custom_scalars` the generated code for the `DateTime` scalar will be 
`type DateTime = crate::custom_scalars::DateTime;`

### How it can be used
 - From the graphql-client
   ```sh
    graphql-client generate query.graphql --schema-path schema.graphql --custom-scalars-module='crate::custom_scalars'
   ```
- deriving
   ```rust
    #[derive(GraphQLQuery)]
    #[graphql(
        schema_path = "schema.graphql",
        query_path = "query.graphql",
        custom_scalars_module = "crate::custom_scalars",
    )]
    pub struct MyQuery;
   ```

Closes #245