### PR TITLE
Remove static lifetime from generated code

### DIFF
--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -86,8 +86,8 @@ impl<'a> GeneratedModule<'a> {
 
                 use std::result::Result;
 
-                pub const OPERATION_NAME: &'static str = #operation_name;
-                pub const QUERY: &'static str = #query_string;
+                pub const OPERATION_NAME: &str = #operation_name;
+                pub const QUERY: &str = #query_string;
 
                 #query_include
 

--- a/graphql_client_codegen/src/query.rs
+++ b/graphql_client_codegen/src/query.rs
@@ -608,7 +608,7 @@ impl UsedTypes {
             .map(move |enum_id| (enum_id, schema.get_enum(enum_id)))
     }
 
-    pub(crate) fn fragment_ids(& self) -> impl Iterator<Item = ResolvedFragmentId> + '_ {
+    pub(crate) fn fragment_ids(&self) -> impl Iterator<Item = ResolvedFragmentId> + '_ {
         self.fragments.iter().copied()
     }
 }

--- a/graphql_client_codegen/src/query.rs
+++ b/graphql_client_codegen/src/query.rs
@@ -608,7 +608,7 @@ impl UsedTypes {
             .map(move |enum_id| (enum_id, schema.get_enum(enum_id)))
     }
 
-    pub(crate) fn fragment_ids<'b>(&'b self) -> impl Iterator<Item = ResolvedFragmentId> + 'b {
+    pub(crate) fn fragment_ids(& self) -> impl Iterator<Item = ResolvedFragmentId> + '_ {
         self.fragments.iter().copied()
     }
 }


### PR DESCRIPTION
I was wondering if it was possible to avoid to generate these `'static` lifetimes.

It would avoid to trigger the [clippy warning](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes) on generated code.
```
constants have by default a `'static` lifetime
```
