### PR TITLE
Disambiguate enum deserialize.

### DIFF
--- a/graphql_client_codegen/src/codegen/enums.rs
+++ b/graphql_client_codegen/src/codegen/enums.rs
@@ -75,7 +75,7 @@ pub(super) fn generate_enum_definitions<'a, 'schema: 'a>(
 
             impl<'de> ::serde::Deserialize<'de> for #name {
                 fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                    let s = <String>::deserialize(deserializer)?;
+                    let s: String = ::serde::Deserialize::deserialize(deserializer)?;
 
                     match s.as_str() {
                         #(#variant_str => Ok(#constructors),)*


### PR DESCRIPTION
Having a trait in scope that defines a `deserialize` function to common
types will generate a [rustc E0034 error](https://doc.rust-lang.org/error-index.html#E0034):

```
error[E0034]: multiple applicable items in scope
   --> src/file_where_things_happened.rs:216:10
    |
216 | #[derive(GraphQLQuery)]
    |          ^^^^^^^^^^^^
    |          |
    |          multiple `deserialize` found
    |          in this macro invocation
    | 
   ::: /home/ignition/projects/oss/graphql-client/graphql_query_derive/src/lib.rs:17:1
    |
17  | pub fn derive_graphql_query(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
    | -------------------------------------------------------------------------------------- in this expansion of `#[derive(GraphQLQuery)]`
    |
    = note: candidate #1 is defined in an impl of the trait `_::_serde::Deserialize` for the type `std::string::String`
    = note: candidate #2 is defined in an impl of the trait `my_other_module::MyTrait` for the type `M`
help: disambiguate the associated function for candidate #1
    |
216 | #[derive(_::_serde::Deserialize::deserialize)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: disambiguate the associated function for candidate #2
    |
216 | #[derive(my_other_module::MyTrait::deserialize)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0034`.
```

This change makes sure this won't happen to anyone anymore .