### PR TITLE
Support Paths in response derives.

### DIFF
--- a/graphql_client/tests/more_derives.rs
+++ b/graphql_client/tests/more_derives.rs
@@ -4,7 +4,7 @@ use graphql_client::*;
 #[graphql(
     schema_path = "tests/more_derives/schema.graphql",
     query_path = "tests/more_derives/query.graphql",
-    response_derives = "Debug, PartialEq, PartialOrd"
+    response_derives = "Debug, PartialEq, std::cmp::PartialOrd"
 )]
 pub struct MoreDerives;
 

--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -165,7 +165,10 @@ fn generate_scalar_definitions<'a, 'schema: 'a>(
 }
 
 fn render_derives<'a>(derives: impl Iterator<Item = &'a str>) -> impl quote::ToTokens {
-    let idents = derives.map(|s| Ident::new(s, Span::call_site()));
+    let idents = derives.map(|s| {
+        syn::parse_str::<syn::Path>(s)
+            .expect(format!("couldn't parse {} as a derive Path", s).as_str())
+    });
 
     quote!(#[derive(#(#idents),*)])
 }

--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -167,7 +167,8 @@ fn generate_scalar_definitions<'a, 'schema: 'a>(
 fn render_derives<'a>(derives: impl Iterator<Item = &'a str>) -> impl quote::ToTokens {
     let idents = derives.map(|s| {
         syn::parse_str::<syn::Path>(s)
-            .expect(format!("couldn't parse {} as a derive Path", s).as_str())
+            .map_err(|e| format!("couldn't parse {} as a derive Path: {}", s, e))
+            .unwrap()
     });
 
     quote!(#[derive(#(#idents),*)])


### PR DESCRIPTION
Up until now only [Ident](https://docs.rs/syn/1.0.74/syn/struct.Ident.html) were supported in the response_derives section,
which unfortunately wouldn't allow us to provide fully qualified names.

This commit enables [Path](https://docs.rs/syn/1.0.74/syn/struct.Path.html) support, and provides us with an error message
if we couldn't parse a response_derive as a valid Path.