### PR TITLE
Displays server response when introspection failed

### DIFF
--- a/graphql_client_cli/src/introspect_schema.rs
+++ b/graphql_client_cli/src/introspect_schema.rs
@@ -58,7 +58,10 @@ pub fn introspect_schema(
     } else {
         let status = res.status();
         let error_message = match res.text() {
-            Ok(msg) => format!("HTTP {}: {}", status, msg),
+            Ok(msg) => match serde_json::from_str::<serde_json::Value>(&msg) {
+                Ok(json) => format!("HTTP {}\n{}", status, serde_json::to_string_pretty(&json)?),
+                Err(_) => format!("HTTP {}: {}", status, msg),
+            },
             Err(_) => format!("HTTP {}", status),
         };
         return Err(Error::message(error_message));


### PR DESCRIPTION
When GraphQL introspection fails, the server response may not necessarily be in JSON format. In that case, the CLI failed to parse and display the response.

This PR makes the CLI display the response error message in plain text.

### Example
```
$ graphql-client introspect-schema --authorization <...> https://api.github.com/graphql
```

Result without this PR:
```
Something else happened. Status: 403
Error: error decoding response body: expected value at line 2 column 1
Location: [...]\graphql_client_cli-0.10.0\src\introspect_schema.rs:61:45
```

Result with this PR:
```
Error: HTTP 403 Forbidden: 
Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.
```