### PR TITLE
Delete .cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'


### PR DESCRIPTION
We do not use wasm-bindgen-test-runner anymore.