### PR TITLE
Annotate variable struct fields too

### DIFF
--- a/graphql_client_codegen/src/codegen.rs
+++ b/graphql_client_codegen/src/codegen.rs
@@ -133,11 +133,9 @@ fn generate_variable_struct_field(
     query: &BoundQuery<'_>,
 ) -> TokenStream {
     let snake_case_name = variable.name.to_snake_case();
-    let ident = Ident::new(
-        &shared::keyword_replace(&snake_case_name),
-        Span::call_site(),
-    );
-    let annotation = shared::field_rename_annotation(&variable.name, &snake_case_name);
+    let safe_name = shared::keyword_replace(&snake_case_name);
+    let ident = Ident::new(&safe_name, Span::call_site());
+    let annotation = shared::field_rename_annotation(&variable.name, &safe_name);
     let r#type = render_variable_field_type(variable, options, query);
 
     quote::quote!(#annotation pub #ident : #r#type)


### PR DESCRIPTION
This PR attempts to properly rename variable struct fields.

Before this PR, variable field names do not carry `#[serde]` annotation that establishes mapping between the safe name and the original schema name. With this PR, the derive macro will attach those annotation labels to renamed fields.