### PR TITLE
[draft] graphql-parser: 0.2 -> 0.3

### DIFF
--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 graphql-introspection-query = { version = "0.2.0", path = "../graphql-introspection-query" }
-graphql-parser = "^0.2"
+graphql-parser = "0.3"
 heck = "0.3"
 lazy_static = "1.3"
 proc-macro2 = { version = "^1.0", features = [] }

--- a/graphql_client_codegen/src/codegen/enums.rs
+++ b/graphql_client_codegen/src/codegen/enums.rs
@@ -11,11 +11,14 @@ use quote::quote;
  * Generated "variant_names" enum:  pub enum AnEnum { where_, self_, Other(String), }
  * Generated serialize line: "AnEnum::where_ => "where","
  */
-pub(super) fn generate_enum_definitions<'a, 'schema: 'a>(
+pub(super) fn generate_enum_definitions<'a, 'b: 'a, 'c, 'schema: 'a, T>(
     all_used_types: &'a crate::query::UsedTypes,
-    options: &'a GraphQLClientCodegenOptions,
-    query: BoundQuery<'schema>,
-) -> impl Iterator<Item = TokenStream> + 'a {
+    options: &'b GraphQLClientCodegenOptions,
+    query: &'c BoundQuery<'a, '_, 'schema, T>,
+) -> impl Iterator<Item = TokenStream> + 'a
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     let derives = render_derives(
         options
             .all_response_derives()

--- a/graphql_client_codegen/src/codegen/inputs.rs
+++ b/graphql_client_codegen/src/codegen/inputs.rs
@@ -8,12 +8,15 @@ use heck::SnakeCase;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
-pub(super) fn generate_input_object_definitions(
+pub(super) fn generate_input_object_definitions<'a, 'schema, T>(
     all_used_types: &UsedTypes,
     options: &GraphQLClientCodegenOptions,
     variable_derives: &impl quote::ToTokens,
-    query: &BoundQuery<'_>,
-) -> Vec<TokenStream> {
+    query: &BoundQuery<'a, '_, 'schema, T>,
+) -> Vec<TokenStream>
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     all_used_types
         .inputs(query.schema)
         .map(|(_input_id, input)| {

--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -24,15 +24,21 @@ impl Display for OperationNotFound {
 impl Error for OperationNotFound {}
 
 /// This struct contains the parameters necessary to generate code for a given operation.
-pub(crate) struct GeneratedModule<'a> {
+pub(crate) struct GeneratedModule<'a, T>
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     pub operation: &'a str,
     pub query_string: &'a str,
-    pub resolved_query: &'a crate::query::Query,
+    pub resolved_query: &'a crate::query::Query<'a, T>,
     pub schema: &'a crate::schema::Schema,
     pub options: &'a crate::GraphQLClientCodegenOptions,
 }
 
-impl<'a> GeneratedModule<'a> {
+impl<'a, T> GeneratedModule<'a, T>
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     /// Generate the items for the variables and the response that will go inside the module.
     fn build_impls(&self) -> Result<TokenStream, BoxError> {
         Ok(crate::codegen::response_for_query(

--- a/graphql_client_codegen/src/query/fragments.rs
+++ b/graphql_client_codegen/src/query/fragments.rs
@@ -15,7 +15,13 @@ impl ResolvedFragment {
     }
 }
 
-pub(crate) fn fragment_is_recursive(fragment_id: ResolvedFragmentId, query: &Query) -> bool {
+pub(crate) fn fragment_is_recursive<'a, T>(
+    fragment_id: ResolvedFragmentId,
+    query: &'a Query<'a, T>,
+) -> bool
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     let fragment = query.get_fragment(fragment_id);
 
     query

--- a/graphql_client_codegen/src/query/validation.rs
+++ b/graphql_client_codegen/src/query/validation.rs
@@ -1,9 +1,12 @@
 use super::{full_path_prefix, BoundQuery, Query, QueryValidationError, Selection, SelectionId};
 use crate::schema::TypeId;
 
-pub(super) fn validate_typename_presence(
-    query: &BoundQuery<'_>,
-) -> Result<(), QueryValidationError> {
+pub(super) fn validate_typename_presence<'a, T>(
+    query: &BoundQuery<'a, '_, '_, T>,
+) -> Result<(), QueryValidationError>
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     for fragment in query.query.fragments.iter() {
         let type_id = match fragment.on {
             id @ TypeId::Interface(_) | id @ TypeId::Union(_) => id,
@@ -46,11 +49,14 @@ pub(super) fn validate_typename_presence(
     Ok(())
 }
 
-fn selection_set_contains_type_name(
+fn selection_set_contains_type_name<'a, T>(
     parent_type_id: TypeId,
     selection_set: &[SelectionId],
-    query: &Query,
-) -> bool {
+    query: &Query<'a, T>,
+) -> bool
+where
+    T: graphql_parser::query::Text<'a> + std::default::Default,
+{
     for id in selection_set {
         let selection = query.get_selection(*id);
 

--- a/graphql_client_codegen/src/schema/tests/github.rs
+++ b/graphql_client_codegen/src/schema/tests/github.rs
@@ -7,7 +7,8 @@ const SCHEMA_GRAPHQL: &str = include_str!("github_schema.graphql");
 fn ast_from_graphql_and_json_produce_the_same_schema() {
     let json: graphql_introspection_query::introspection_response::IntrospectionResponse =
         serde_json::from_str(SCHEMA_JSON).unwrap();
-    let graphql_parser_schema = graphql_parser::parse_schema(SCHEMA_GRAPHQL).unwrap();
+    let graphql_parser_schema: graphql_parser::schema::Document<'_, String> =
+        graphql_parser::parse_schema(SCHEMA_GRAPHQL).unwrap();
     let mut json = Schema::from(json);
     let mut gql = Schema::from(graphql_parser_schema);
 

--- a/graphql_client_codegen/src/tests/mod.rs
+++ b/graphql_client_codegen/src/tests/mod.rs
@@ -3,9 +3,11 @@ use crate::{generated_module, schema::Schema, CodegenMode, GraphQLClientCodegenO
 #[test]
 fn schema_with_keywords_works() {
     let query_string = include_str!("keywords_query.graphql");
-    let query = graphql_parser::parse_query(query_string).expect("Parse keywords query");
-    let schema = graphql_parser::parse_schema(include_str!("keywords_schema.graphql"))
-        .expect("Parse keywords schema");
+    let query: graphql_parser::query::Document<'_, String> =
+        graphql_parser::parse_query(query_string).expect("Parse keywords query");
+    let schema: graphql_parser::schema::Document<'_, String> =
+        graphql_parser::parse_schema(include_str!("keywords_schema.graphql"))
+            .expect("Parse keywords schema");
     let schema = Schema::from(schema);
 
     let options = GraphQLClientCodegenOptions::new(CodegenMode::Cli);
@@ -41,9 +43,11 @@ fn schema_with_keywords_works() {
 #[test]
 fn fragments_other_variant_should_generate_unknown_other_variant() {
     let query_string = include_str!("foobars_query.graphql");
-    let query = graphql_parser::parse_query(query_string).expect("Parse foobars query");
-    let schema = graphql_parser::parse_schema(include_str!("foobars_schema.graphql"))
-        .expect("Parse foobars schema");
+    let query: graphql_parser::query::Document<'_, String> =
+        graphql_parser::parse_query(query_string).expect("Parse foobars query");
+    let schema: graphql_parser::schema::Document<'_, String> =
+        graphql_parser::parse_schema(include_str!("foobars_schema.graphql"))
+            .expect("Parse foobars schema");
     let schema = Schema::from(schema);
 
     let mut options = GraphQLClientCodegenOptions::new(CodegenMode::Cli);
@@ -80,9 +84,11 @@ fn fragments_other_variant_should_generate_unknown_other_variant() {
 #[test]
 fn fragments_other_variant_false_should_not_generate_unknown_other_variant() {
     let query_string = include_str!("foobars_query.graphql");
-    let query = graphql_parser::parse_query(query_string).expect("Parse foobars query");
-    let schema = graphql_parser::parse_schema(include_str!("foobars_schema.graphql"))
-        .expect("Parse foobars schema");
+    let query: graphql_parser::query::Document<'_, String> =
+        graphql_parser::parse_query(query_string).expect("Parse foobars query");
+    let schema: graphql_parser::schema::Document<'_, String> =
+        graphql_parser::parse_schema(include_str!("foobars_schema.graphql"))
+            .expect("Parse foobars schema");
     let schema = Schema::from(schema);
 
     let options = GraphQLClientCodegenOptions::new(CodegenMode::Cli);

--- a/graphql_client_codegen/src/type_qualifiers.rs
+++ b/graphql_client_codegen/src/type_qualifiers.rs
@@ -10,7 +10,10 @@ impl GraphqlTypeQualifier {
     }
 }
 
-pub fn graphql_parser_depth(schema_type: &graphql_parser::schema::Type) -> usize {
+pub fn graphql_parser_depth<'a, T>(schema_type: &graphql_parser::schema::Type<'a, T>) -> usize
+where
+    T: graphql_parser::query::Text<'a>,
+{
     match schema_type {
         graphql_parser::schema::Type::ListType(inner) => 1 + graphql_parser_depth(inner),
         graphql_parser::schema::Type::NonNullType(inner) => 1 + graphql_parser_depth(inner),


### PR DESCRIPTION
An attempt at upgrading the `graphql-parser` dependency to the latest version.

Unfortunately, this is a huge PITA due to fundamental changes in how graphql-parser handles the underlying text data. IIUC in previous versions `String`s were just copied around and ownership of an AST node implied ownership of all the data necessary to print out what it is. However in the latest version, the seems to have changed to AST nodes only owning pointers with non-local lifetimes into the underlying text data. See eg https://docs.rs/graphql-parser/0.3.0/graphql_parser/query/trait.Text.html which is now the underlying trait for text data.

I'm not at all familiar with the graphql-client or graphql-parser codebases, so I only attempted a relatively naive "play-with-lifetimes" approach. I've sunk enough hours into this already, and I'm stuck at this point so putting this out there as a draft PR for anyone to extend/adapt/fix as they'd like!