### PR TITLE
graphql_client_codegen: trim whitespace from derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- The `variables_derives` now trims whitespace from individual derivation traits.
+
 ## 0.10.0 - 2021-07-04
 
 - The `web` feature is dropped. You can now use a `reqwest::Client` instead of the custom HTTP client.

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -102,7 +102,8 @@ impl GraphQLClientCodegenOptions {
             .variables_derives
             .as_deref()
             .into_iter()
-            .flat_map(|s| s.split(','));
+            .flat_map(|s| s.split(','))
+            .map(|s| s.trim());
 
         std::iter::once("Serialize").chain(additional)
     }


### PR DESCRIPTION
This is done already in the `response_derives`, but was missed for
variables.