### PR TITLE
Added extension support

### DIFF
--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -290,8 +290,9 @@ pub struct Response<Data> {
     pub data: Option<Data>,
     /// The top-level errors returned by the server.
     pub errors: Option<Vec<Error>>,
-    /// The top-level errors returned by the server.
-    pub extensions: Option<serde_json::Value>,
+    /// Additional extensions. Their exact format is defined by the server.
+    /// See [GraphQL Response Specification](https://github.com/graphql/graphql-spec/blob/main/spec/Section%207%20--%20Response.md#response-format)
+    pub extensions: Option<HashMap<String, serde_json::Value>>,
 }
 
 #[cfg(test)]

--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -181,6 +181,7 @@ impl Display for PathFragment {
 ///             extensions: None,
 ///         },
 ///     ]),
+///     extensions: None,
 /// };
 ///
 /// assert_eq!(body, expected);
@@ -275,6 +276,7 @@ impl Display for Error {
 ///         dogs: vec![Dog { name: "Strelka".to_owned() }],
 ///     }),
 ///     errors: Some(vec![]),
+///     extensions: None,
 /// };
 ///
 /// assert_eq!(body, expected);
@@ -288,6 +290,8 @@ pub struct Response<Data> {
     pub data: Option<Data>,
     /// The top-level errors returned by the server.
     pub errors: Option<Vec<Error>>,
+    /// The top-level errors returned by the server.
+    pub extensions: Option<serde_json::Value>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added support for extensions as a `serde_json::Value`. This can be further converted into a concrete type with the use of `serde_json::from_value`.

Related: #367 