### PR TITLE
Add feature to use reqwest with rustls rather than native-tls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 - The `variables_derives` now trims whitespace from individual derivation traits.
+- The new `reqwest-rustls` feature works like the `reqwest` feature but with
+  `rustls` rather than `native-tls`.
 
 ## 0.10.0 - 2021-07-04
 

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 homepage = "https://github.com/graphql-rust/graphql-client"
 readme = "../README.md"
 
+[package.metadata.docs.rs]
+features = ["reqwest"]
+
 [dependencies]
 serde = { version = "^1.0.78", features = ["derive"] }
 serde_json = "1.0"

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -17,8 +17,10 @@ serde_json = "1.0"
 
 # Optional dependencies
 graphql_query_derive = { path = "../graphql_query_derive", version = "0.10.0", optional = true }
-reqwest = { version = "^0.11", features = ["json"], optional = true }
+reqwest-crate = { package = "reqwest", version = "^0.11", features = ["json"], default-features = false, optional = true }
 
 [features]
 default = ["graphql_query_derive"]
-reqwest-blocking = ["reqwest/blocking"]
+reqwest = ["reqwest-crate", "reqwest-crate/default-tls"]
+reqwest-rustls = ["reqwest-crate", "reqwest-crate/rustls-tls"]
+reqwest-blocking = ["reqwest-crate/blocking"]

--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -23,7 +23,7 @@ extern crate graphql_query_derive;
 #[doc(hidden)]
 pub use graphql_query_derive::*;
 
-#[cfg(any(feature = "reqwest", feature = "reqwest-blocking"))]
+#[cfg(any(feature = "reqwest", feature = "reqwest-rustls", feature = "reqwest-blocking"))]
 pub mod reqwest;
 
 use serde::{Deserialize, Serialize};

--- a/graphql_client/src/reqwest.rs
+++ b/graphql_client/src/reqwest.rs
@@ -1,9 +1,10 @@
 //! A concrete client implementation over HTTP with reqwest.
 
 use crate::GraphQLQuery;
+use reqwest_crate as reqwest;
 
 /// Use the provided reqwest::Client to post a GraphQL request.
-#[cfg(feature = "reqwest")]
+#[cfg(any(feature = "reqwest", feature = "reqwest-rustls"))]
 pub async fn post_graphql<Q: GraphQLQuery, U: reqwest::IntoUrl>(
     client: &reqwest::Client,
     url: U,


### PR DESCRIPTION
Currently, enabling the `reqwest` feature pulls in native-tls. This is annoying in a project that otherwise uses rustls. This change adds a new feature `reqwest-rustls` that also adds the `reqwest` module, but using `reqwest` with rustls rather than native-tls.