### PR TITLE
s/Hash/BTree/g in codegen to make the output deterministic

### DIFF
--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -32,7 +32,7 @@ pub mod reqwest;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Write};
 
 /// A convenience trait that can be used to build a GraphQL request body.
 ///
@@ -215,7 +215,7 @@ impl Display for Error {
                 fragments
                     .iter()
                     .fold(String::new(), |mut acc, item| {
-                        acc.push_str(&format!("{}/", item));
+                        let _ = write!(acc, "{}/", item);
                         acc
                     })
                     .trim_end_matches('/')

--- a/graphql_client_codegen/src/query.rs
+++ b/graphql_client_codegen/src/query.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fmt::Display,
 };
 
@@ -42,7 +42,7 @@ impl QueryValidationError {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct SelectionId(u32);
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct OperationId(u32);
@@ -53,7 +53,7 @@ impl OperationId {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ResolvedFragmentId(u32);
 
 #[derive(Debug, Clone, Copy)]
@@ -509,7 +509,7 @@ where
 pub(crate) struct Query {
     fragments: Vec<ResolvedFragment>,
     operations: Vec<ResolvedOperation>,
-    selection_parent_idx: HashMap<SelectionId, SelectionParent>,
+    selection_parent_idx: BTreeMap<SelectionId, SelectionParent>,
     selections: Vec<Selection>,
     variables: Vec<ResolvedVariable>,
 }
@@ -620,8 +620,8 @@ impl ResolvedVariable {
 
 #[derive(Debug, Default)]
 pub(crate) struct UsedTypes {
-    pub(crate) types: HashSet<TypeId>,
-    fragments: HashSet<ResolvedFragmentId>,
+    pub(crate) types: BTreeSet<TypeId>,
+    fragments: BTreeSet<ResolvedFragmentId>,
 }
 
 impl UsedTypes {

--- a/graphql_client_codegen/src/schema.rs
+++ b/graphql_client_codegen/src/schema.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::query::UsedTypes;
 use crate::type_qualifiers::GraphqlTypeQualifier;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) const DEFAULT_SCALARS: &[&str] = &["ID", "String", "Int", "Float", "Boolean"];
 
@@ -44,25 +44,25 @@ pub(crate) enum StoredFieldParent {
     Interface(InterfaceId),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) struct ObjectId(u32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
 pub(crate) struct ObjectFieldId(usize);
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) struct InterfaceId(usize);
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) struct ScalarId(usize);
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) struct UnionId(usize);
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) struct EnumId(usize);
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) struct InputId(u32);
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -98,7 +98,7 @@ pub(crate) struct StoredScalar {
     pub(crate) name: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub(crate) enum TypeId {
     Object(ObjectId),
     Scalar(ScalarId),
@@ -222,7 +222,7 @@ pub(crate) struct Schema {
     stored_scalars: Vec<StoredScalar>,
     stored_enums: Vec<StoredEnum>,
     stored_inputs: Vec<StoredInputType>,
-    names: HashMap<String, TypeId>,
+    names: BTreeMap<String, TypeId>,
 
     pub(crate) query_type: Option<ObjectId>,
     pub(crate) mutation_type: Option<ObjectId>,
@@ -239,7 +239,7 @@ impl Schema {
             stored_scalars: Vec::with_capacity(DEFAULT_SCALARS.len()),
             stored_enums: Vec::new(),
             stored_inputs: Vec::new(),
-            names: HashMap::new(),
+            names: BTreeMap::new(),
             query_type: None,
             mutation_type: None,
             subscription_type: None,
@@ -404,7 +404,7 @@ impl StoredInputType {
         &'a self,
         input_id: InputId,
         schema: &'a Schema,
-        visited_types: &mut HashSet<&'a str>,
+        visited_types: &mut BTreeSet<&'a str>,
     ) -> bool {
         visited_types.insert(&self.name);
         // The input type is recursive if any of its members contains it, without indirection
@@ -440,7 +440,7 @@ impl StoredInputType {
 
 pub(crate) fn input_is_recursive_without_indirection(input_id: InputId, schema: &Schema) -> bool {
     let input = schema.get_input(input_id);
-    let mut visited_types = HashSet::<&str>::new();
+    let mut visited_types = BTreeSet::<&str>::new();
     input.contains_type_without_indirection(input_id, schema, &mut visited_types)
 }
 impl<'doc, T> std::convert::From<graphql_parser::schema::Document<'doc, T>> for Schema

--- a/graphql_client_codegen/src/schema/json_conversion.rs
+++ b/graphql_client_codegen/src/schema/json_conversion.rs
@@ -14,7 +14,6 @@ pub(super) fn build_schema(src: IntrospectionResponse) -> Schema {
 
 fn build_names_map(src: &mut JsonSchema, schema: &mut Schema) {
     let names = &mut schema.names;
-    names.reserve(types_mut(src).count());
 
     unions_mut(src)
         .map(|u| u.name.as_ref().expect("union name"))


### PR DESCRIPTION
We were seeing cases where `#[derive(GraphqlQuery)]` was not generating
consistent output. This appeared to be due to the use of `HashMap` and
`HashSet`, whose iteration order is not guaranteed to be consistent.
Switching to `BTreeMap` and `BTreeSet` appears to fix the issue.