### PR TITLE
Improve error message when query name is missing

### DIFF
--- a/graphql_client_codegen/src/query.rs
+++ b/graphql_client_codegen/src/query.rs
@@ -154,7 +154,7 @@ where
             ) => {
                 let on = schema.query_type();
                 let resolved_operation: ResolvedOperation = ResolvedOperation {
-                    name: q.name.as_ref().expect("query without name").as_ref().into(),
+                    name: q.name.as_ref().expect("query without name. Instead of `query (...)`, write `query SomeName(...)` in your .graphql file").as_ref().into(),
                     _operation_type: operations::OperationType::Query,
                     object_id: on,
                     selection_set: Vec::with_capacity(q.selection_set.items.len()),


### PR DESCRIPTION
Thanks for this project!

I'm not used to working with GraphQL, so the current short error message confused me. I did not understand what kind of name was missing at first. Eventually I figured it out.

Make the error message more helpful by hinting what the likely (only?) problem is.