### PR TITLE
Support codegen from query string

### DIFF
--- a/examples/github/examples/schema.graphql
+++ b/examples/github/examples/schema.graphql
@@ -2410,7 +2410,7 @@ type IssueTimelineConnection {
 
 "An item in an issue timeline"
 union IssueTimelineItem =
-    AssignedEvent
+  | AssignedEvent
   | ClosedEvent
   | Commit
   | CrossReferencedEvent
@@ -5009,7 +5009,7 @@ type PullRequestTimelineConnection {
 
 "An item in an pull request timeline"
 union PullRequestTimelineItem =
-    AssignedEvent
+  | AssignedEvent
   | BaseRefForcePushedEvent
   | ClosedEvent
   | Commit
@@ -6940,7 +6940,7 @@ type ReviewRequestedEvent implements Node {
 
 "The results of a search."
 union SearchResultItem =
-    Issue
+  | Issue
   | MarketplaceListing
   | Organization
   | PullRequest

--- a/graphql_client_codegen/src/schema/tests/github_schema.graphql
+++ b/graphql_client_codegen/src/schema/tests/github_schema.graphql
@@ -2409,7 +2409,7 @@ type IssueTimelineConnection {
 
 "An item in an issue timeline"
 union IssueTimelineItem =
-    AssignedEvent
+  | AssignedEvent
   | ClosedEvent
   | Commit
   | CrossReferencedEvent
@@ -5008,7 +5008,7 @@ type PullRequestTimelineConnection {
 
 "An item in an pull request timeline"
 union PullRequestTimelineItem =
-    AssignedEvent
+  | AssignedEvent
   | BaseRefForcePushedEvent
   | ClosedEvent
   | Commit
@@ -6939,7 +6939,7 @@ type ReviewRequestedEvent implements Node {
 
 "The results of a search."
 union SearchResultItem =
-    Issue
+  | Issue
   | MarketplaceListing
   | Organization
   | PullRequest


### PR DESCRIPTION
## Context

Our crate generates the GraphQL query that [uses the macro to generate Rust types](https://github.com/Shopify/shopify-function-rust/blob/48167961252422e8e45b43b448dc290d65074450/shopify_function_macro/src/lib.rs#L363-L373). We want to avoid [writing the generated query to a temporary file](https://github.com/Shopify/shopify-function-rust/blob/48167961252422e8e45b43b448dc290d65074450/shopify_function_macro/src/lib.rs#L351).

## Proposal

- Refactor `graphql_client_codegen` and expose a function to generate module token stream from a query string (instead of a query path)
- Maintain backwards-compatibility with the existing `generate_module_token_stream`