### PR TITLE
codegen: enable ids to be deserialized from strings or integers

### DIFF
--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -30,6 +30,8 @@ pub use graphql_query_derive::*;
 ))]
 pub mod reqwest;
 
+pub mod serde_with;
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{self, Display, Write};

--- a/graphql_client/src/serde_with.rs
+++ b/graphql_client/src/serde_with.rs
@@ -1,0 +1,27 @@
+//! Helpers for overriding default serde implementations.
+
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize an optional ID type from either a String or an Integer representation.
+///
+/// This is used by the codegen to enable String IDs to be deserialized from
+/// either Strings or Integers.
+pub fn deserialize_option_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IntOrString {
+        Int(i64),
+        Str(String),
+    }
+
+    let res = Option::<IntOrString>::deserialize(deserializer)?;
+
+    Ok(match res {
+        None => None,
+        Some(IntOrString::Int(n)) => Some(n.to_string()),
+        Some(IntOrString::Str(s)) => Some(s),
+    })
+}

--- a/graphql_client/tests/int_id.rs
+++ b/graphql_client/tests/int_id.rs
@@ -1,0 +1,41 @@
+use graphql_client::*;
+use serde_json::json;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "tests/more_derives/schema.graphql",
+    query_path = "tests/more_derives/query.graphql",
+    response_derives = "Debug, PartialEq, Eq, std::cmp::PartialOrd"
+)]
+pub struct MoreDerives;
+
+#[test]
+fn int_id() {
+    let response1 = json!({
+        "currentUser": {
+            "id": 1,
+            "name": "Don Draper",
+        }
+    });
+
+    let response2 = json!({
+        "currentUser": {
+            "id": "2",
+            "name": "Peggy Olson",
+        }
+    });
+
+    let res1 = serde_json::from_value::<more_derives::ResponseData>(response1)
+        .expect("should deserialize");
+    assert_eq!(
+        res1.current_user.expect("res1 current user").id,
+        Some("1".into())
+    );
+
+    let res2 = serde_json::from_value::<more_derives::ResponseData>(response2)
+        .expect("should deserialize");
+    assert_eq!(
+        res2.current_user.expect("res2 current user").id,
+        Some("2".into())
+    );
+}

--- a/graphql_client/tests/int_id/query.graphql
+++ b/graphql_client/tests/int_id/query.graphql
@@ -1,0 +1,6 @@
+query MoreDerives {
+  currentUser {
+    name
+    id
+  }
+}

--- a/graphql_client/tests/int_id/schema.graphql
+++ b/graphql_client/tests/int_id/schema.graphql
@@ -1,0 +1,12 @@
+schema {
+  query: TestQuery
+}
+
+type TestQuery {
+  currentUser: TestUser
+}
+
+type TestUser {
+  name: String
+  id: ID
+}

--- a/graphql_client_codegen/src/codegen/selection.rs
+++ b/graphql_client_codegen/src/codegen/selection.rs
@@ -405,6 +405,14 @@ impl<'a> ExpandedField<'a> {
             qualified_type
         };
 
+        let id_deserialize_with = if self.field_type == "ID" {
+            Some(
+                quote!(#[serde(deserialize_with = "graphql_client::serde_with::deserialize_option_id")]),
+            )
+        } else {
+            None
+        };
+
         let optional_skip_serializing_none = if *options.skip_serializing_none()
             && self
                 .field_type_qualifiers
@@ -443,6 +451,7 @@ impl<'a> ExpandedField<'a> {
             #optional_flatten
             #optional_rename
             #optional_deprecation_annotation
+            #id_deserialize_with
             pub #ident: #qualified_type
         };
 


### PR DESCRIPTION
Although not strictly to spec, some upstream graphql implementations such as the start.gg
API encode their ID types as integers rather than strings. Prior to this commit,
deserialization would fail in such cases, since graphql_client simply type aliases the ID
type to a String. This commit introduces a simple deserialization helper that enables us
to handle both integers and strings while maintaining backward compatbility for downstream
users.

Fixes: https://github.com/graphql-rust/graphql-client/issues/455