### PR TITLE
fix: Use consistent reference to graphql_client crate in codegen

### DIFF
--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -104,7 +104,7 @@ impl<'a> GeneratedModule<'a> {
                 type Variables = #module_name::Variables;
                 type ResponseData = #module_name::ResponseData;
 
-                fn build_query(variables: Self::Variables) -> ::graphql_client::QueryBody<Self::Variables> {
+                fn build_query(variables: Self::Variables) -> graphql_client::QueryBody<Self::Variables> {
                     graphql_client::QueryBody {
                         variables,
                         query: #module_name::QUERY,


### PR DESCRIPTION
https://github.com/graphql-rust/graphql-client/issues/483