### PR TITLE
refs #439. Fix skip_serializing_none for root level variables

### DIFF
--- a/graphql_client/tests/skip_serializing_none.rs
+++ b/graphql_client/tests/skip_serializing_none.rs
@@ -13,7 +13,10 @@ fn skip_serializing_none() {
     use skip_serializing_none_mutation::*;
 
     let query = SkipSerializingNoneMutation::build_query(Variables {
-        foo: None,
+        optional_int: None,
+        optional_list: None,
+        non_optional_int: 1337,
+        non_optional_list: vec![],
         param: Some(Param {
             data: Author {
                 name: "test".to_owned(),
@@ -26,10 +29,17 @@ fn skip_serializing_none() {
 
     println!("{}", stringified);
 
-    assert!(stringified.contains(r#""variables":{"param":{"data":{"name":"test"}}}"#));
+    assert!(stringified.contains(r#""param":{"data":{"name":"test"}}"#));
+    assert!(stringified.contains(r#""nonOptionalInt":1337"#));
+    assert!(stringified.contains(r#""nonOptionalList":[]"#));
+    assert!(!stringified.contains(r#""optionalInt""#));
+    assert!(!stringified.contains(r#""optionalLint""#));
 
     let query = SkipSerializingNoneMutation::build_query(Variables {
-        foo: Some(42),
+        optional_int: Some(42),
+        optional_list: Some(vec![]),
+        non_optional_int: 1337,
+        non_optional_list: vec![],
         param: Some(Param {
             data: Author {
                 name: "test".to_owned(),
@@ -39,5 +49,9 @@ fn skip_serializing_none() {
     });
     let stringified = serde_json::to_string(&query).expect("SkipSerializingNoneMutation is valid");
     println!("{}", stringified);
-    assert!(stringified.contains(r#""variables":{"param":{"data":{"name":"test"}},"foo":42}"#));
+    assert!(stringified.contains(r#""param":{"data":{"name":"test"}}"#));
+    assert!(stringified.contains(r#""nonOptionalInt":1337"#));
+    assert!(stringified.contains(r#""nonOptionalList":[]"#));
+    assert!(stringified.contains(r#""optionalInt":42"#));
+    assert!(stringified.contains(r#""optionalList":[]"#));
 }

--- a/graphql_client/tests/skip_serializing_none.rs
+++ b/graphql_client/tests/skip_serializing_none.rs
@@ -33,7 +33,7 @@ fn skip_serializing_none() {
     assert!(stringified.contains(r#""nonOptionalInt":1337"#));
     assert!(stringified.contains(r#""nonOptionalList":[]"#));
     assert!(!stringified.contains(r#""optionalInt""#));
-    assert!(!stringified.contains(r#""optionalLint""#));
+    assert!(!stringified.contains(r#""optionalList""#));
 
     let query = SkipSerializingNoneMutation::build_query(Variables {
         optional_int: Some(42),

--- a/graphql_client/tests/skip_serializing_none.rs
+++ b/graphql_client/tests/skip_serializing_none.rs
@@ -13,6 +13,7 @@ fn skip_serializing_none() {
     use skip_serializing_none_mutation::*;
 
     let query = SkipSerializingNoneMutation::build_query(Variables {
+        foo: None,
         param: Some(Param {
             data: Author {
                 name: "test".to_owned(),
@@ -25,5 +26,18 @@ fn skip_serializing_none() {
 
     println!("{}", stringified);
 
-    assert!(stringified.contains(r#""data":{"name":"test"}"#));
+    assert!(stringified.contains(r#""variables":{"param":{"data":{"name":"test"}}}"#));
+
+    let query = SkipSerializingNoneMutation::build_query(Variables {
+        foo: Some(42),
+        param: Some(Param {
+            data: Author {
+                name: "test".to_owned(),
+                id: None,
+            },
+        }),
+    });
+    let stringified = serde_json::to_string(&query).expect("SkipSerializingNoneMutation is valid");
+    println!("{}", stringified);
+    assert!(stringified.contains(r#""variables":{"param":{"data":{"name":"test"}},"foo":42}"#));
 }

--- a/graphql_client/tests/skip_serializing_none/query.graphql
+++ b/graphql_client/tests/skip_serializing_none/query.graphql
@@ -1,4 +1,4 @@
-mutation SkipSerializingNoneMutation($param: Param) {
+mutation SkipSerializingNoneMutation($param: Param, $foo: Int) {
   optInput(query: $param) {
     name
     __typename

--- a/graphql_client/tests/skip_serializing_none/query.graphql
+++ b/graphql_client/tests/skip_serializing_none/query.graphql
@@ -1,4 +1,4 @@
-mutation SkipSerializingNoneMutation($param: Param, $foo: Int) {
+mutation SkipSerializingNoneMutation($param: Param, $optionalInt: Int, $optionalList: [Int!], $nonOptionalInt: Int!, $nonOptionalList: [Int!]!) {
   optInput(query: $param) {
     name
     __typename


### PR DESCRIPTION
- Check if root level variables are `Option` values and skip serializing with serde if the `skip_serializing_none` option is set
- Update test case appropriately