### PR TITLE
Allow using `#[derive(GraphQLQuery)]` without depending on serde

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dev-dependencies]
 anyhow = "1.0"
 graphql_client = { path = "../../graphql_client", features = ["reqwest-blocking"] }
-serde = "^1.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 prettytable-rs = "^0.10.0"
 clap = { version = "^3.0", features = ["derive"] }

--- a/examples/hasura/Cargo.toml
+++ b/examples/hasura/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dev-dependencies]
 anyhow = "1.0"
 graphql_client = { path = "../../graphql_client", features = ["reqwest-blocking"] }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
 prettytable-rs = "0.10.0"

--- a/examples/web/Cargo.toml
+++ b/examples/web/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 graphql_client = { path = "../../graphql_client", features = ["reqwest"] }
 wasm-bindgen = "^0.2"
-serde = { version = "1.0.67", features = ["derive"] }
 lazy_static = "1.0.1"
 js-sys = "0.3.6"
 wasm-bindgen-futures = "0.4.18"

--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -299,6 +299,12 @@ pub struct Response<Data> {
     pub extensions: Option<HashMap<String, serde_json::Value>>,
 }
 
+/// Hidden module for types used by the codegen crate.
+#[doc(hidden)]
+pub mod _private {
+    pub use ::serde;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/graphql_client_codegen/src/codegen/enums.rs
+++ b/graphql_client_codegen/src/codegen/enums.rs
@@ -16,6 +16,7 @@ pub(super) fn generate_enum_definitions<'a, 'schema: 'a>(
     options: &'a GraphQLClientCodegenOptions,
     query: BoundQuery<'schema>,
 ) -> impl Iterator<Item = TokenStream> + 'a {
+    let serde = options.serde_path();
     let traits = options
         .all_response_derives()
         .chain(options.all_variable_derives())
@@ -66,8 +67,8 @@ pub(super) fn generate_enum_definitions<'a, 'schema: 'a>(
                 Other(String),
             }
 
-            impl ::serde::Serialize for #name {
-                fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            impl #serde::Serialize for #name {
+                fn serialize<S: #serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
                     ser.serialize_str(match *self {
                         #(#constructors => #variant_str,)*
                         #name::Other(ref s) => &s,
@@ -75,9 +76,9 @@ pub(super) fn generate_enum_definitions<'a, 'schema: 'a>(
                 }
             }
 
-            impl<'de> ::serde::Deserialize<'de> for #name {
-                fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                    let s: String = ::serde::Deserialize::deserialize(deserializer)?;
+            impl<'de> #serde::Deserialize<'de> for #name {
+                fn deserialize<D: #serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                    let s: String = #serde::Deserialize::deserialize(deserializer)?;
 
                     match s.as_str() {
                         #(#variant_str => Ok(#constructors),)*

--- a/graphql_client_codegen/src/codegen/inputs.rs
+++ b/graphql_client_codegen/src/codegen/inputs.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
+use quote::{quote, ToTokens};
 
 pub(super) fn generate_input_object_definitions(
     all_used_types: &UsedTypes,
@@ -33,6 +33,9 @@ fn generate_struct(
     variable_derives: &impl quote::ToTokens,
     query: &BoundQuery<'_>,
 ) -> TokenStream {
+    let serde = options.serde_path();
+    let serde_path = serde.to_token_stream().to_string();
+
     let normalized_name = options.normalization().input_name(input.name.as_str());
     let safe_name = keyword_replace(normalized_name);
     let struct_name = Ident::new(safe_name.as_ref(), Span::call_site());
@@ -71,6 +74,7 @@ fn generate_struct(
 
     quote! {
         #variable_derives
+        #[serde(crate = #serde_path)]
         pub struct #struct_name{
             #(#fields,)*
         }

--- a/graphql_client_codegen/src/codegen_options.rs
+++ b/graphql_client_codegen/src/codegen_options.rs
@@ -47,6 +47,8 @@ pub struct GraphQLClientCodegenOptions {
     fragments_other_variant: bool,
     /// Skip Serialization of None values.
     skip_serializing_none: bool,
+    /// Path to the serde crate.
+    serde_path: syn::Path,
 }
 
 impl GraphQLClientCodegenOptions {
@@ -68,6 +70,7 @@ impl GraphQLClientCodegenOptions {
             extern_enums: Default::default(),
             fragments_other_variant: Default::default(),
             skip_serializing_none: Default::default(),
+            serde_path: syn::parse_quote!(::serde),
         }
     }
 
@@ -226,5 +229,15 @@ impl GraphQLClientCodegenOptions {
     /// Get a reference to the graphql client codegen option's skip none value.
     pub fn skip_serializing_none(&self) -> &bool {
         &self.skip_serializing_none
+    }
+
+    /// Set the path to used to resolve serde traits.
+    pub fn set_serde_path(&mut self, path: syn::Path) {
+        self.serde_path = path;
+    }
+
+    /// Get a reference to the path used to resolve serde traits.
+    pub fn serde_path(&self) -> &syn::Path {
+        &self.serde_path
     }
 }

--- a/graphql_query_derive/src/lib.rs
+++ b/graphql_query_derive/src/lib.rs
@@ -104,6 +104,7 @@ fn build_graphql_client_derive_options(
     options.set_struct_ident(input.ident.clone());
     options.set_module_visibility(input.vis.clone());
     options.set_operation_name(input.ident.to_string());
+    options.set_serde_path(syn::parse_quote!(graphql_client::_private::serde));
 
     Ok(options)
 }


### PR DESCRIPTION
This PR makes the serde derives emitted by `#[derive(GraphQLQuery)]` use a private re-export of the serde crate instead of relying on users of this crate having added serde to their `Cargo.toml`.

Serde allows you to add an annotation

    #[serde(crate = "<path to crate>")]

for exactly this reason so most of this PR is just plumbing the correct path through the codegen crate to the correct annotation.

Details
-------
- There is a new `#[doc(hidden)] mod _private` declaration in the `graphql_client` crate. All re-exports (which is just serde) have been placed there.
- I have added a new `serde_path` field to `GraphQLCodegenOptions` which defaults to `::serde`. This means that the code generated by the CLI should remain effectively unchanged.
- The rest is just applying `#[serde(crate = ...)]` annotations where appropriate.

Fixes #427