### PR TITLE
graphql_client_cli: newline in warning suppression

### DIFF
--- a/graphql_client_cli/src/generate.rs
+++ b/graphql_client_cli/src/generate.rs
@@ -80,7 +80,7 @@ pub(crate) fn generate_code(params: CliCodegenParams) -> CliResult<()> {
     let gen = generate_module_token_stream(query_path.clone(), &schema_path, options)
         .map_err(|err| Error::message(format!("Error generating module code: {}", err)))?;
 
-    let generated_code = format!("{}\n{}", WARNING_SUPPRESSION, gen);
+    let generated_code = format!("{}\n\n{}", WARNING_SUPPRESSION, gen);
     let generated_code = if !no_formatting {
         format(&generated_code)?
     } else {


### PR DESCRIPTION
Before this change, the warning suppression was being erroneously applied to the first query item.

Fixes #491