### PR TITLE
ci: test minimal version of dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,13 @@ jobs:
       run: sudo apt update && sudo apt-get install -y nodejs
     - name: Execute prettier
       run: npx prettier --debug-check -l './**/*.json' './**/*.graphql'
+
+  minimal-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --all-features


### PR DESCRIPTION
Use `cargo minimal-versions` to check whether the minimal specified versions dependencies successfully compiles.

As this repo has no `Cargo.lock`, CI will always test with the newest compatible dependency versions. This new job will check oldest compatible dependency version as well.

This requires unstable nightly feature `minimal-versions`, but they abstracted away by `cargo-minimal-versions` project.

`prost` uses the same job for several months: https://github.com/tokio-rs/prost/blob/21208abf667313866f79d3d1438310c4dc20bdff/.github/workflows/ci.yml#L168-L176