### PR TITLE
build(deps): update `reqwest` to 0.12

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 graphql_client = { path = "../../graphql_client", features = ["reqwest-blocking"] }
 serde = "^1.0"
-reqwest = { version = "^0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 prettytable-rs = "^0.7"
 clap = { version = "^3.0", features = ["derive"] }
 log = "^0.4"

--- a/examples/hasura/Cargo.toml
+++ b/examples/hasura/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 graphql_client = { path = "../../graphql_client", features = ["reqwest-blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "^0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 prettytable-rs = "0.7.0"
 log = "0.4.3"
 env_logger = "0.5.10"

--- a/examples/web/Cargo.toml
+++ b/examples/web/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.67", features = ["derive"] }
 lazy_static = "1.0.1"
 js-sys = "0.3.6"
 wasm-bindgen-futures = "0.4.18"
-reqwest = "0.11.3"
+reqwest = "0.12"
 
 [dependencies.web-sys]
 version = "0.3.6"

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 
 # Optional dependencies
 graphql_query_derive = { path = "../graphql_query_derive", version = "0.14.0", optional = true }
-reqwest-crate = { package = "reqwest", version = "^0.11", features = ["json"], default-features = false, optional = true }
+reqwest-crate = { package = "reqwest", version = ">=0.11, <=0.12", features = ["json"], default-features = false, optional = true }
 
 [features]
 default = ["graphql_query_derive"]

--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "graphql-client"
 path = "src/main.rs"
 
 [dependencies]
-reqwest = { version = "^0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 graphql_client = { version = "0.14.0", path = "../graphql_client", default-features = false, features = ["graphql_query_derive", "reqwest-blocking"] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.14.0" }
 clap = { version = "^3.0", features = ["derive"] }


### PR DESCRIPTION
Use a version range in the library crate, as both `reqwest` 0.11 and 0.12 are compatible for our usage.

Alternative for #490 as mentioned in https://github.com/graphql-rust/graphql-client/pull/490#issuecomment-2306729677