### PR TITLE
doc: fix multiple operations example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ use graphql_client::GraphQLQuery;
     schema_path = "tests/unions/union_schema.graphql",
     query_path = "tests/unions/union_query.graphql",
 )]
-pub struct UnionQuery;
+pub struct Heights;
 ```
 
 There is an example [in the tests](./graphql_client/tests/operation_selection).


### PR DESCRIPTION
In the graphql file specified in the readme for the multiple operation part, the operations are called `Heights` and `Echo`, while the struct is called `UnionQuery` and the text states that

> Note that the struct and the operation in the GraphQL file must have the same name.

I think that's either a confusing oversight or a mistake