### PR TITLE
Fix RUSTSEC-2022-0074 / GHSA-gfgm-chr3-x6px moderate security issue in examples

### DIFF
--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 graphql_client = { path = "../../graphql_client", features = ["reqwest-blocking"] }
 serde = "^1.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-prettytable-rs = "^0.7"
+prettytable-rs = "^0.10.0"
 clap = { version = "^3.0", features = ["derive"] }
 log = "^0.4"
 env_logger = "^0.5"

--- a/examples/hasura/Cargo.toml
+++ b/examples/hasura/Cargo.toml
@@ -10,6 +10,6 @@ graphql_client = { path = "../../graphql_client", features = ["reqwest-blocking"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-prettytable-rs = "0.7.0"
+prettytable-rs = "0.10.0"
 log = "0.4.3"
 env_logger = "0.5.10"


### PR DESCRIPTION
This PR is purely a nit fix; in my IDE, I have a supply chain vulnerability tool that makes working in the repository annoying if there's a security issue it knows about. This just bumps the version of prettytable-rs to a version that has been fixed (according to the security report).