### PR TITLE
build(deps): update `heck` to 0.5

### DIFF
--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 graphql-introspection-query = { version = "0.2.0", path = "../graphql-introspection-query" }
 graphql-parser = "0.4"
-heck = "0.4.0"
+heck = ">=0.4, <=0.5"
 lazy_static = "1.3"
 proc-macro2 = { version = "^1.0", features = [] }
 quote = "^1.0"


### PR DESCRIPTION
Use a version range in the library crate, as both `heck` 0.4 and 0.5 are compatible for our usage.