### PR TITLE
style: Remove explicit lifetimes

### DIFF
--- a/graphql_client_codegen/src/codegen/selection.rs
+++ b/graphql_client_codegen/src/codegen/selection.rs
@@ -391,7 +391,7 @@ struct ExpandedField<'a> {
     boxed: bool,
 }
 
-impl<'a> ExpandedField<'a> {
+impl ExpandedField<'_> {
     fn render(&self, options: &GraphQLClientCodegenOptions) -> Option<TokenStream> {
         let ident = Ident::new(&self.rust_name, Span::call_site());
         let qualified_type = decorate_type(
@@ -457,7 +457,7 @@ struct ExpandedVariant<'a> {
     is_default_variant: bool,
 }
 
-impl<'a> ExpandedVariant<'a> {
+impl ExpandedVariant<'_> {
     fn render(&self) -> TokenStream {
         let name_ident = Ident::new(&self.name, Span::call_site());
         let optional_type_ident = self.variant_type.as_ref().map(|variant_type| {

--- a/graphql_client_codegen/src/generated_module.rs
+++ b/graphql_client_codegen/src/generated_module.rs
@@ -32,7 +32,7 @@ pub(crate) struct GeneratedModule<'a> {
     pub options: &'a crate::GraphQLClientCodegenOptions,
 }
 
-impl<'a> GeneratedModule<'a> {
+impl GeneratedModule<'_> {
     /// Generate the items for the variables and the response that will go inside the module.
     fn build_impls(&self) -> Result<TokenStream, BoxError> {
         Ok(crate::codegen::response_for_query(


### PR DESCRIPTION
This solves clippy warnings like this:
```
error: the following explicit lifetimes could be elided: 'a
   --> graphql_client_codegen/src/codegen/selection.rs:394:6
    |
394 | impl<'a> ExpandedField<'a> {
    |      ^^                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
    |
394 - impl<'a> ExpandedField<'a> {
394 + impl ExpandedField<'_> {
    |
```