### PR TITLE
Adding a pretty debug implementation to overcome escaping of strings

### DIFF
--- a/graphql_client/src/lib.rs
+++ b/graphql_client/src/lib.rs
@@ -89,7 +89,7 @@ pub trait GraphQLQuery {
 }
 
 /// The form in which queries are sent over HTTP in most implementations. This will be built using the [`GraphQLQuery`] trait normally.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct QueryBody<Variables> {
     /// The values for the variables. They must match those declared in the queries. This should be the `Variables` struct from the generated module corresponding to the query.
     pub variables: Variables,
@@ -100,6 +100,28 @@ pub struct QueryBody<Variables> {
     pub operation_name: &'static str,
 }
 
+struct PrettyStr<'a>(&'a str);
+
+impl<'a> fmt::Debug for PrettyStr<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use `{}` (Display) instead of `{:?}` (Debug) to avoid escaping newlines.
+        write!(f, "\"{}\"", self.0)
+    }
+}
+
+impl<Variables: fmt::Debug> fmt::Debug for QueryBody<Variables> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryBody")
+            .field("variables", &self.variables)
+            // Replace the escaped literal "\n" with actual newline characters.
+            // This is necessary because when using code-generation,
+            // multi-line strings in macros are escaped and become a single
+            // line string in the generated code
+            .field("query", &PrettyStr(self.query))
+            .field("operation_name", &self.operation_name)
+            .finish()
+    }
+}
 /// Represents a location inside a query string. Used in errors. See [`Error`].
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Location {

--- a/graphql_client/tests/readable_debug.rs
+++ b/graphql_client/tests/readable_debug.rs
@@ -1,0 +1,40 @@
+use graphql_client::*;
+use opt_query::Param;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "tests/default/query.graphql",
+    schema_path = "tests/default/schema.graphql",
+    variables_derives = "Default, Debug"
+)]
+struct OptQuery;
+
+fn normalize_whitespace(s: &str) -> String {
+    s.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn query_is_formatted_correctly() {
+    let variables = opt_query::Variables {
+        param: Some(Param::AUTHOR),
+    };
+    let query = OptQuery::build_query(variables);
+    let debug_output = format!("{:#?}", query);
+
+    let original_query = include_str!("default/query.graphql");
+
+    // Normalize both for comparison
+    let normalized_debug_output = normalize_whitespace(&debug_output);
+    let normalized_original_query = normalize_whitespace(original_query);
+
+    assert!(
+        normalized_debug_output.contains(&normalized_original_query),
+        "Debug output did not contain the expected query.\nDebug output:\n{}\n\nExpected query:\n{}",
+        normalized_debug_output,
+        normalized_original_query
+    );
+}


### PR DESCRIPTION
As described in #518 , parsing a string and include it in code generation generates code like so:

```
            pub mod repository_with_pull_requests {
                #![allow(dead_code)]
                use std::result::Result;
                pub const OPERATION_NAME: &str = "RepositoryWithPullRequests";
                pub const QUERY: &str = "query RepositoryWithPullRequests(\n  $repositoryName: String!\n  $repositoryOwner: String!\n  $count: Int!\n  $pullRequestStates: [PullRequestState!]!\n) {\n  repository(name: $repositoryName, owner: $repositoryOwner) {\n    owner {\n      __typename\n      login\n    }\n    name\n    defaultBranchRef {\n      name\n    }\n    pullRequests(first: $count, states: $pullRequestStates) {\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n\n      totalCount\n      nodes {\n        author {\n          __typename\n          login\n        }\n        id\n        url\n        title\n        state\n        createdAt\n        updatedAt\n        closedAt\n        ## uh-oh not very safe but it's ok\n        labels(first: 100) {\n          edges {\n            node {\n              id\n              name\n            }\n          }\n        }\n      }\n    }\n  }\n}\n";
                const __QUERY_WORKAROUND: &str = "query RepositoryWithPullRequests(\n  $repositoryName: String!\n  $repositoryOwner: String!\n  $count: Int!\n  $pullRequestStates: [PullRequestState!]!\n) {\n  repository(name: $repositoryName, owner: $repositoryOwner) {\n    owner {\n      __typename\n      login\n    }\n    name\n    defaultBranchRef {\n      name\n    }\n    pullRequests(first: $count, states: $pullRequestStates) {\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n\n      totalCount\n      nodes {\n        author {\n          __typename\n          login\n        }\n        id\n        url\n        title\n        state\n        createdAt\n        updatedAt\n        closedAt\n        ## uh-oh not very safe but it\'s ok\n        labels(first: 100) {\n          edges {\n            node {\n              id\n              name\n            }\n          }\n        }\n      }\n    }\n  }\n}\n";
```

instead of a multi-line string. A solution would be to reduce reusability in macros:

```rust
pub fn generate_module_token_stream(
    query_path: std::path::PathBuf,
    schema_path: &std::path::Path,
    options: GraphQLClientCodegenOptions,
) -> Result<TokenStream, BoxError> {
    let query = get_set_query_from_file(query_path.as_path());
    let schema = get_set_schema_from_file(schema_path);

    generate_module_token_stream_inner(&query, &schema, options)
}

/// Generates Rust code given a query string, a path to a schema file, and options.
pub fn generate_module_token_stream_from_string(
    query_string: &str,
    schema_path: &std::path::Path,
    options: GraphQLClientCodegenOptions,
) -> Result<TokenStream, BoxError> {
    let query = (query_string.to_string(), query_document(query_string)?);
    let schema = get_set_schema_from_file(schema_path);

    generate_module_token_stream_inner(&query, &schema, options)
}
```

so that we propagate the path of the file and we use `include_str!` macro in code-generation if we have something from file, which would require us to modify

```rust
/// This struct contains the parameters necessary to generate code for a given operation.
pub(crate) struct GeneratedModule<'a> {
    pub operation: &'a str,
    pub query_string: &'a str,
    pub resolved_query: &'a crate::query::Query,
    pub schema: &'a crate::schema::Schema,
    pub options: &'a crate::GraphQLClientCodegenOptions,
}
```

to support a query that's either a String or a PathBuf and then at macro time doing either an include or a simple quoting

