### PR TITLE
Upgrade Syn and add cli option for extern enums

### DIFF
--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = "^0.4"
 env_logger = "^0.6"
-syn = "1.0"
+syn = { version = "^2.0", features = ["full"] }
 
 [features]
 default = []

--- a/graphql_client_cli/src/main.rs
+++ b/graphql_client_cli/src/main.rs
@@ -89,6 +89,9 @@ enum Cli {
         /// --fragments-other-variant
         #[clap(long = "fragments-other-variant")]
         fragments_other_variant: bool,
+        /// List of externally defined enum types. Type names must match those used in the schema exactly
+        #[clap(long = "external-enums", num_args(0..), action(clap::ArgAction::Append))]
+        external_enums: Option<Vec<String>>,
     },
 }
 
@@ -126,6 +129,7 @@ fn main() -> CliResult<()> {
             selected_operation,
             custom_scalars_module,
             fragments_other_variant,
+            external_enums,
         } => generate::generate_code(generate::CliCodegenParams {
             query_path,
             schema_path,
@@ -138,6 +142,7 @@ fn main() -> CliResult<()> {
             output_directory,
             custom_scalars_module,
             fragments_other_variant,
+            external_enums,
         }),
     }
 }

--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro2 = { version = "^1.0", features = [] }
 quote = "^1.0"
 serde_json = "1.0"
 serde = { version = "^1.0", features = ["derive"] }
-syn = "^1.0"
+syn = { version = "^2.0", features = [ "full" ] }

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "^1.0", features = ["extra-traits"] }
+syn = { version = "^2.0", features = ["extra-traits"] }
 proc-macro2 = { version = "^1.0", features = [] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.14.0" }


### PR DESCRIPTION
This pull request brings the dependency syn from 1.x to 2.0, which required several changes to the code, which highlighted that external_enum didn't have effective testing; through the validation process, I isolated it to the derive logic in attributes, and the tests started to pass correctly.

All of the tests are passing; the code has been fmt'd. Hopefully, this is ok.