### PR TITLE
Correctly set minimal versions for graphql_client

### DIFF
--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -16,8 +16,8 @@ rust-version.workspace = true
 features = ["reqwest"]
 
 [dependencies]
-serde = { version = "^1.0.78", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.78", features = ["derive"] }
+serde_json = "1.0.50"
 
 # Optional dependencies
 graphql_query_derive = { path = "../graphql_query_derive", version = "0.14.0", optional = true }


### PR DESCRIPTION
Currently, the minimal version for serde_json is set incorrectly, it requires `Eq` to be implemented for `serde_json::Value`, yet this was only introduced in 1.0.50. Also removed a [redundant caret](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) in the serde dependency.

One other small consideration might be necessary for reqwest. Currently, the reqwest version is bound by `>=0.11, <=0.12`. 
~~This seems odd, as in theory this would allow all of `0.11.x`, but also `0.12.y`. A quick test shows that Cargo refuses to select `0.12.y` in this case. I am not sure if this is a bug in Cargo as well.~~

~~But to get back to this crate. If the idea is that everything in `0.11.x` would be okay, but not `0.12.y` the canonical way of defining this would be just `0.11.0` (or `0.11` if you want to be implicit). If `0.12.y` should be selected too, I would just like to inform you that this seems to be currently unsupported by Cargo.~~

Never mind that last part, I was looking at 0.14 instead of main, my bad. I still think that `>=0.11.0, <0.13.0` would be clearer, but that is simply preference.