### PR TITLE
feat: Adding deprecation fields to InputValue

### DIFF
--- a/graphql-introspection-query/src/introspection_response.rs
+++ b/graphql-introspection-query/src/introspection_response.rs
@@ -202,7 +202,9 @@ pub struct InputValue {
     #[serde(rename = "type")]
     pub type_: InputValueType,
     pub default_value: Option<String>,
+    #[serde(default)]
     pub is_deprecated: Option<bool>,
+    #[serde(default)]
     pub deprecation_reason: Option<String>,
 }
 


### PR DESCRIPTION
Adding support to deprecated directive on `InputValue` as defined in https://spec.graphql.org/September2025/#sec--deprecated.

This will also help us  to solve a bug on http://github.com/apollographql/rover where the rover graph introspection does not correctly fetch the `@deprecated` directives from the introspected schema.