### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.15.0 - 2025-12-08
 
 - Support for `deprecated` directive on InputValue fields (#553)
 - Support for custom variable and response types (#536)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "graphql-introspection-query"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "graphql_client"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "graphql_query_derive",
  "reqwest",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anstyle",
  "clap",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ members = [
 ]
 
 [workspace.package]
+version = "0.15.0"
 rust-version = "1.64.0"

--- a/examples/github/Cargo.toml
+++ b/examples/github/Cargo.toml
@@ -3,6 +3,7 @@ name = "graphql_query_github_example"
 version = "0.1.0"
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2018"
+publish = false
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/examples/hasura/Cargo.toml
+++ b/examples/hasura/Cargo.toml
@@ -3,6 +3,7 @@ name = "graphql_query_hasura_example"
 version = "0.1.0"
 authors = ["Mark Catley <mark@catley.net.nz>"]
 edition = "2018"
+publish = false
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/examples/web/Cargo.toml
+++ b/examples/web/Cargo.toml
@@ -3,6 +3,7 @@ name = "web"
 version = "0.1.0"
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2018"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/graphql-introspection-query/Cargo.toml
+++ b/graphql-introspection-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-introspection-query"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2018"
 keywords = ["graphql", "api", "web"]

--- a/graphql_client/Cargo.toml
+++ b/graphql_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql_client"
-version = "0.14.0"
+version.workspace = true
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 description = "Typed GraphQL requests and responses"
 repository = "https://github.com/graphql-rust/graphql-client"
@@ -10,7 +10,7 @@ categories = ["network-programming", "web-programming", "wasm"]
 edition = "2018"
 homepage = "https://github.com/graphql-rust/graphql-client"
 readme = "../README.md"
-rust-version.workspace = true 
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["reqwest"]
@@ -20,7 +20,7 @@ serde = { version = "1.0.78", features = ["derive"] }
 serde_json = "1.0.50"
 
 # Optional dependencies
-graphql_query_derive = { path = "../graphql_query_derive", version = "0.14.0", optional = true }
+graphql_query_derive = { path = "../graphql_query_derive", version = "0.15.0", optional = true }
 reqwest-crate = { package = "reqwest", version = ">=0.11, <=0.12", features = ["json"], default-features = false, optional = true }
 
 [features]

--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "graphql_client_cli"
 description = "The CLI for graphql-client"
-version = "0.14.0"
+version.workspace = true
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/graphql-rust/graphql-client"
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-graphql_client = { version = "0.14.0", path = "../graphql_client", default-features = false, features = ["graphql_query_derive", "reqwest-blocking"] }
-graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.14.0" }
+graphql_client = { version = "0.15.0", path = "../graphql_client", default-features = false, features = ["graphql_query_derive", "reqwest-blocking"] }
+graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.15.0" }
 clap = { version = "^4.0", features = ["derive"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"

--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql_client_codegen"
-version = "0.14.0"
+version.workspace = true
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 description = "Utility crate for graphql_client"
 license = "Apache-2.0 OR MIT"
@@ -8,7 +8,7 @@ repository = "https://github.com/graphql-rust/graphql-client"
 edition = "2018"
 
 [dependencies]
-graphql-introspection-query = { version = "0.2.0", path = "../graphql-introspection-query" }
+graphql-introspection-query = { version = "0.3.0", path = "../graphql-introspection-query" }
 graphql-parser = "0.4"
 heck = ">=0.4, <=0.5"
 lazy_static = "1.3"

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql_query_derive"
-version = "0.14.0"
+version.workspace = true
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 description = "Utility crate for graphql_client"
 license = "Apache-2.0 OR MIT"
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 syn = { version = "^2.0", features = ["extra-traits"] }
 proc-macro2 = { version = "^1.0", features = [] }
-graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.14.0" }
+graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.15.0" }


### PR DESCRIPTION
- Support for `deprecated` directive on InputValue fields (#553)
- Support for custom variable and response types (#536)
- Allow using `#[derive(GraphQLQuery)]` without depending on `serde` directly (#487)
- CLI option for extern enums (#520)
- Support deserializing IDs from integers or strings (#476)
- Introspection schema now includes `oneOf` and `specifiedByUrl` (#501)
- Update `reqwest` to 0.12 (#499)
- Fix required ID deserialization (#523)
- Fix `skip_serializing_none` for root level variables (#485)
- Use consistent reference to `graphql_client` crate in codegen (#484)
- Fix multiple operations example in README (#497)