### PR TITLE
Support syn 3.0

### DIFF
--- a/graphql_client_cli/Cargo.toml
+++ b/graphql_client_cli/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = "^0.4"
 env_logger = { version = "0.10.2", features = ["color"] }
-syn = { version = "^2.0", features = ["full"] }
+syn = { version = ">=2.0, <4", features = ["full"] }
 anstyle = "1.0.10"
 
 [features]

--- a/graphql_client_codegen/Cargo.toml
+++ b/graphql_client_codegen/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro2 = { version = "^1.0", features = [] }
 quote = "^1.0"
 serde_json = "1.0"
 serde = { version = "^1.0", features = ["derive"] }
-syn = { version = "^2.0", features = [ "full" ] }
+syn = { version = ">=2.0, <4", features = [ "full" ] }

--- a/graphql_query_derive/Cargo.toml
+++ b/graphql_query_derive/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "^2.0", features = ["extra-traits"] }
+syn = { version = ">=2.0, <4", features = ["extra-traits"] }
 proc-macro2 = { version = "^1.0", features = [] }
 graphql_client_codegen = { path = "../graphql_client_codegen/", version = "0.16.0" }


### PR DESCRIPTION
Widens the `syn` requirement to `>=2.0, <4` so consumers already on `syn` 3 can unify the graph. Requirement only, no lockfile bump: `syn` 3.0 needs Rust 1.71 and this crate advertises 1.66, so the committed lock stays on `syn` 2. Refs #569.

The Rustfmt check failure looks pre-existing and unrelated: it flags a `__TypeKind` import order in `graphql_client_codegen/src/schema/json_conversion.rs`, a file this PR does not touch. `main` is red on the same job.